### PR TITLE
Modify SDK Versioning

### DIFF
--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectManager.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectManager.m
@@ -27,9 +27,6 @@
 #import "DConnectOriginParser.h"
 #import "LocalOAuth2Main.h"
 
-NSString *const DConnectManagerName = @"Device Connect Manager";
-NSString *const DConnectManagerVersion = @"2.0.0";
-
 NSString *const DConnectApplicationDidEnterBackground = @"DConnectApplicationDidEnterBackground";
 NSString *const DConnectApplicationWillEnterForeground = @"DConnectApplicationWillEnterForeground";
 NSString *const DConnectStoryboardName = @"DConnectSDK";
@@ -284,8 +281,8 @@ NSString *const DConnectAttributeNameRequestAccessToken = @"requestAccessToken";
 }
 
 - (void) sendResponse:(DConnectResponseMessage *)response {
-    [response setString:DConnectManagerName forKey:DConnectMessageProduct];
-    [response setString:DConnectManagerVersion forKey:DConnectMessageVersion];
+    [response setString:self.productName forKey:DConnectMessageProduct];
+    [response setString:self.versionName forKey:DConnectMessageVersion];
     
     DConnectResponseCallbackInfo *info = nil;
     @synchronized (_mResponseBlockMap) {
@@ -316,6 +313,8 @@ NSString *const DConnectAttributeNameRequestAccessToken = @"requestAccessToken";
         
         // DConnect設定を初期化
         _settings = [DConnectSettings new];
+        self.productName = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleDisplayName"];
+        self.versionName = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleShortVersionString"];
         
         // イベント管理クラス
         Class key = [self class];
@@ -345,8 +344,8 @@ NSString *const DConnectAttributeNameRequestAccessToken = @"requestAccessToken";
 - (void) executeRequest:(DConnectRequestMessage *)request
                response:(DConnectResponseMessage *)response
                callback:(DConnectResponseBlocks)callback {
-    [request setString:DConnectManagerName forKey:DConnectMessageProduct];
-    [request setString:DConnectManagerVersion forKey:DConnectMessageVersion];
+    [request setString:self.productName forKey:DConnectMessageProduct];
+    [request setString:self.versionName forKey:DConnectMessageVersion];
     
     DConnectProfile *profile = [self profileWithName:[request profile]];
     

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectURLProtocol.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectURLProtocol.m
@@ -319,8 +319,8 @@ static NSString *scheme = @"http";
             NSString *name = [exception name];
             DConnectResponseMessage * response = [DConnectResponseMessage new];
             [response setResult:DConnectMessageResultTypeError];
-            [response setVersion:DConnectManagerVersion];
-            [response setProduct:DConnectManagerName];
+            [response setVersion:[DConnectManager sharedManager].versionName];
+            [response setProduct:[DConnectManager sharedManager].productName];
             if ([name isEqualToString:HAVE_NO_API_EXCEPTION]) {
                 responseCtx.response = [[NSHTTPURLResponse alloc] initWithURL:[request URL]
                                                                    statusCode:404

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectManager.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectManager.h
@@ -18,16 +18,6 @@
 #import <DConnectSDk/DConnectSettings.h>
 
 /*!
- @brief Device Connect Managerの表示用の名前。
- */
-extern NSString *const DConnectManagerName;
-
-/*!
- @brief Device Connect Managerのバージョン名。
- */
-extern NSString *const DConnectManagerVersion;
-
-/*!
  @brief アプリケーションがホームボタン押下で一時停止されたことを通知するイベント名。
  */
 extern NSString *const DConnectApplicationDidEnterBackground;
@@ -86,6 +76,16 @@ extern NSString *const DConnectApplicationWillEnterForeground;
  @attention WebSocket経由でイベントを受け取る場合はnilを設定する必要がある。
  */
 @property (nonatomic, weak) id<DConnectManagerDelegate> delegate;
+
+/*!
+ @brief DConnectManagerの製品名。
+ */
+@property (nonatomic) NSString *productName;
+
+/*!
+ @brief DConnectManagerのバージョン名。
+ */
+@property (nonatomic) NSString *versionName;
 
 /*!
  @brief DConnectManagerのインスタンスを取得する。


### PR DESCRIPTION
Default product name and version name are dConnectBrowser's display name and version name.

Apps of SDK have the option to set other preferred names by setProductName and setVersionName of DConnectManager.
