### PR TITLE
Fix notification parameter validation logic in Host device plugin.

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostNotificationProfile.m
+++ b/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostNotificationProfile.m
@@ -162,9 +162,7 @@ didReceivePostNotifyRequest:(DConnectRequestMessage *)request
         [response setError:100 message:@"body is nill"];
         return YES;
     }
-    NSString *typeString = [request stringForKey:DConnectNotificationProfileParamType];
-    if (!type || type.intValue < 0 || 3 < type.intValue
-        || (type && ![DPHostUtils existDigitWithString:typeString])) {
+    if (!type || type.intValue < 0 || 3 < type.intValue) {
         [response setErrorToInvalidRequestParameterWithMessage:@"type is null or invalid"];
         return YES;
     }

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectMessage.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectMessage.m
@@ -398,7 +398,7 @@ NSString *const DConnectMessageHeaderGotAPIOrigin = @"X-GotAPI-Origin";
     id obj = [self.dictionary objectForKey:aKey];
     if ([obj isKindOfClass:[NSString class]]) {
         int val;
-        if ([[NSScanner scannerWithString:obj] scanInt:&int]) {
+        if ([[NSScanner scannerWithString:obj] scanInt:&val]) {
             return [NSNumber numberWithInt:val];
         } else {
             return nil;

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectMessage.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectMessage.m
@@ -397,7 +397,12 @@ NSString *const DConnectMessageHeaderGotAPIOrigin = @"X-GotAPI-Origin";
 - (NSNumber *) numberForKey:(NSString *)aKey {
     id obj = [self.dictionary objectForKey:aKey];
     if ([obj isKindOfClass:[NSString class]]) {
-        return [NSNumber numberWithDouble:[((NSString *) obj) doubleValue]];
+        int val;
+        if ([[NSScanner scannerWithString:obj] scanInt:&int]) {
+            return [NSNumber numberWithInt:val];
+        } else {
+            return nil;
+        }
     }
     return (NSNumber *) [self.dictionary objectForKey:aKey];
 }


### PR DESCRIPTION
Notification API POST wrongly assumed the original data of parameter "type" to be a string -  it's actually a number - and that caused an error.
