### PR TITLE
[iOS]dConnectBrowserが開いている場合URLスキームがうまく起動しない

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
@@ -135,6 +135,11 @@
 
 - (void)openSafariViewInternalWithURL:(NSString*)url
 {
+    AppDelegate* delegate = [UIApplication sharedApplication].delegate;
+    if (delegate.window.rootViewController.presentedViewController != nil) {
+        [self dismissViewControllerAnimated:false completion:nil];
+    }
+
     //文字列がURLの場合
     _url = [self.manager isURLString:url];
     if ([url rangeOfString:@"#"].location != NSNotFound) {

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
@@ -13,9 +13,7 @@
 #import <DConnectSDK/DConnectSDK.h>
 #import <SafariServices/SafariServices.h>
 #import "AppDelegate.h"
-@interface ViewController (){
-    SFSafariViewController *sfSafariViewController;
-}
+@interface ViewController (){}
 
 @property (nonatomic, strong) GHURLManager *manager;
 @property (nonatomic) NSString* url;
@@ -148,7 +146,7 @@
         _url = [self.manager createSearchURL:url];
     }
     void (^loadSFSafariViewControllerBlock)(NSURL *) = ^(NSURL *url) {
-        sfSafariViewController = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:YES];
+        SFSafariViewController* sfSafariViewController = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:YES];
         sfSafariViewController.delegate = self;
         [self presentViewController:sfSafariViewController animated:YES completion:nil];
     };
@@ -185,7 +183,7 @@
 }
 
 -(void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
-    [sfSafariViewController dismissViewControllerAnimated:YES completion:nil];
+    [controller dismissViewControllerAnimated:YES completion:nil];
 }
 
 


### PR DESCRIPTION
## Why

[iOS]dConnectBrowserが開いている場合URLスキームがうまく起動しない
## Works
- [x] `- (void)openSafariViewInternalWithURL:(NSString*)url` が呼ばれた場合にモーダル表示しているviewControllerがある場合はdismissしてからURLSchemeの対応をするように修正
- [x] ついでにsfSafariViewControllerをプロパティで保持する必要がなさそうなので削除。（削除してはマズイ場合は教えて下さい！）
