### PR TITLE
[iOS]トップ画面でhttpまたはhttps以外で始まるscheme等を入力するとクラッシュする

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHURLManager.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHURLManager.m
@@ -61,9 +61,10 @@
                 return [url description];
             } else if ([[url scheme] isEqualToString: @"gotapi"] && [[url host] isEqualToString: @"start"]) {
                 //gotapiの場合
-                NSInteger queryWordLenght = 4;
+                NSString* queryURL = @"url=";
+                NSInteger queryWordLenght = queryURL.length;
                 NSString* query = [url query];
-                if (query.length > queryWordLenght) {
+                if (query.length > queryWordLenght && [[query substringWithRange:NSMakeRange(0, queryWordLenght)] isEqualToString:queryURL])  {
                     return [self isURLString: [query substringFromIndex: queryWordLenght]];
                 }
             }

--- a/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHURLManager.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHURLManager.m
@@ -55,9 +55,18 @@
                                                    range:NSMakeRange(0,[urlString length])];
     
     for (NSTextCheckingResult *result in resultArray){
-        if ([result resultType] == NSTextCheckingTypeLink){
+        if ([result resultType] == NSTextCheckingTypeLink) {
             NSURL *url = [result URL];
-            return [url description];
+            if ([[url scheme] isEqualToString: @"http"] || [[url scheme] isEqualToString: @"https"]) {
+                return [url description];
+            } else if ([[url scheme] isEqualToString: @"gotapi"] && [[url host] isEqualToString: @"start"]) {
+                //gotapiの場合
+                NSInteger queryWordLenght = 4;
+                NSString* query = [url query];
+                if (query.length > queryWordLenght) {
+                    return [self isURLString: [query substringFromIndex: queryWordLenght]];
+                }
+            }
         }
     }
     


### PR DESCRIPTION
## Why

[iOS]トップ画面でhttpまたはhttps以外で始まるURLScheme等を入力するとクラッシュする
## Works
- scheme が httpとhttpsのみをURLとみなすように修正。
- schemeがgotoapi、hostがstart、且つqueryにurl=が存在する場合、URLを抽出するように修正。
