### PR TITLE
設定画面の機能追加

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHConfig.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHConfig.h
@@ -23,6 +23,7 @@
 
 #define IS_MANAGER_LAUNCH @"is_manager_launch"
 #define IS_ORIGIN_BLOCKING @"is_origin_blocking"
+#define IS_USE_LOCALOAUTH @"is_useLocalOAuth"
 
 #define PAGE_URL @"pageurl"
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9.xcodeproj/project.pbxproj
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8EBB891A1D1387380038700B /* BookmarkIconViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EBB89191D1387380038700B /* BookmarkIconViewModel.m */; };
 		8EBB891D1D139C750038700B /* TopViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EBB891C1D139C750038700B /* TopViewModel.m */; };
 		8EBB89211D13CA960038700B /* TopCollectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EBB89201D13CA960038700B /* TopCollectionHeaderView.m */; };
+		8ED7B1AD1D1BA4070053FDBD /* GHSettingViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ED7B1AC1D1BA4070053FDBD /* GHSettingViewModel.m */; };
 		AB00F1E41C71941800689C70 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AB00F1E31C71941800689C70 /* main.m */; };
 		AB00F1E71C71941800689C70 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AB00F1E61C71941800689C70 /* AppDelegate.m */; };
 		AB00F1EA1C71941800689C70 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AB00F1E91C71941800689C70 /* ViewController.m */; };
@@ -171,6 +172,8 @@
 		8EBB891E1D13B7C20038700B /* db 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "db 3.xcdatamodel"; sourceTree = "<group>"; };
 		8EBB891F1D13CA960038700B /* TopCollectionHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TopCollectionHeaderView.h; sourceTree = "<group>"; };
 		8EBB89201D13CA960038700B /* TopCollectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TopCollectionHeaderView.m; sourceTree = "<group>"; };
+		8ED7B1AB1D1BA4070053FDBD /* GHSettingViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GHSettingViewModel.h; sourceTree = "<group>"; };
+		8ED7B1AC1D1BA4070053FDBD /* GHSettingViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GHSettingViewModel.m; sourceTree = "<group>"; };
 		AB00F1DF1C71941800689C70 /* dConnectBrowserForIOS9.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = dConnectBrowserForIOS9.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB00F1E31C71941800689C70 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		AB00F1E51C71941800689C70 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -387,6 +390,7 @@
 		8EBB89161D1387010038700B /* viewModel */ = {
 			isa = PBXGroup;
 			children = (
+				8ED7B1AA1D1BA3E40053FDBD /* setting */,
 				8EBB89171D1387090038700B /* top */,
 			);
 			name = viewModel;
@@ -401,6 +405,15 @@
 				8EBB891C1D139C750038700B /* TopViewModel.m */,
 			);
 			name = top;
+			sourceTree = "<group>";
+		};
+		8ED7B1AA1D1BA3E40053FDBD /* setting */ = {
+			isa = PBXGroup;
+			children = (
+				8ED7B1AB1D1BA4070053FDBD /* GHSettingViewModel.h */,
+				8ED7B1AC1D1BA4070053FDBD /* GHSettingViewModel.m */,
+			);
+			name = setting;
 			sourceTree = "<group>";
 		};
 		AB00F1D61C71941800689C70 = {
@@ -943,6 +956,7 @@
 				AB00F2E51C71A29D00689C70 /* GHBookmarkViewController.m in Sources */,
 				AB00F2F61C71A29D00689C70 /* GHToolView.m in Sources */,
 				AB00F1E71C71941800689C70 /* AppDelegate.m in Sources */,
+				8ED7B1AD1D1BA4070053FDBD /* GHSettingViewModel.m in Sources */,
 				AB00F2F51C71A29D00689C70 /* GHSettingController.m in Sources */,
 				AB00F4A81C71B16200689C70 /* RATreeView+Enums.m in Sources */,
 				AB00F2E41C71A29D00689C70 /* GHBookmarkTopController.m in Sources */,

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9.xcodeproj/project.pbxproj
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		8EBB891D1D139C750038700B /* TopViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EBB891C1D139C750038700B /* TopViewModel.m */; };
 		8EBB89211D13CA960038700B /* TopCollectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EBB89201D13CA960038700B /* TopCollectionHeaderView.m */; };
 		8ED7B1AD1D1BA4070053FDBD /* GHSettingViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ED7B1AC1D1BA4070053FDBD /* GHSettingViewModel.m */; };
+		8ED7B1B21D1BB0270053FDBD /* GrayLabelCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ED7B1B11D1BB0270053FDBD /* GrayLabelCell.m */; };
+		8ED7B1B51D1BB03C0053FDBD /* SwitchableCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ED7B1B41D1BB03C0053FDBD /* SwitchableCell.m */; };
+		8ED7B1B81D1BB04A0053FDBD /* DetailableCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ED7B1B71D1BB04A0053FDBD /* DetailableCell.m */; };
 		AB00F1E41C71941800689C70 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AB00F1E31C71941800689C70 /* main.m */; };
 		AB00F1E71C71941800689C70 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AB00F1E61C71941800689C70 /* AppDelegate.m */; };
 		AB00F1EA1C71941800689C70 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AB00F1E91C71941800689C70 /* ViewController.m */; };
@@ -174,6 +177,12 @@
 		8EBB89201D13CA960038700B /* TopCollectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TopCollectionHeaderView.m; sourceTree = "<group>"; };
 		8ED7B1AB1D1BA4070053FDBD /* GHSettingViewModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GHSettingViewModel.h; sourceTree = "<group>"; };
 		8ED7B1AC1D1BA4070053FDBD /* GHSettingViewModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GHSettingViewModel.m; sourceTree = "<group>"; };
+		8ED7B1B01D1BB0270053FDBD /* GrayLabelCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GrayLabelCell.h; sourceTree = "<group>"; };
+		8ED7B1B11D1BB0270053FDBD /* GrayLabelCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GrayLabelCell.m; sourceTree = "<group>"; };
+		8ED7B1B31D1BB03C0053FDBD /* SwitchableCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwitchableCell.h; sourceTree = "<group>"; };
+		8ED7B1B41D1BB03C0053FDBD /* SwitchableCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SwitchableCell.m; sourceTree = "<group>"; };
+		8ED7B1B61D1BB04A0053FDBD /* DetailableCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DetailableCell.h; sourceTree = "<group>"; };
+		8ED7B1B71D1BB04A0053FDBD /* DetailableCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DetailableCell.m; sourceTree = "<group>"; };
 		AB00F1DF1C71941800689C70 /* dConnectBrowserForIOS9.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = dConnectBrowserForIOS9.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB00F1E31C71941800689C70 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		AB00F1E51C71941800689C70 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -416,6 +425,19 @@
 			name = setting;
 			sourceTree = "<group>";
 		};
+		8ED7B1AF1D1BAFFD0053FDBD /* setting */ = {
+			isa = PBXGroup;
+			children = (
+				8ED7B1B01D1BB0270053FDBD /* GrayLabelCell.h */,
+				8ED7B1B11D1BB0270053FDBD /* GrayLabelCell.m */,
+				8ED7B1B31D1BB03C0053FDBD /* SwitchableCell.h */,
+				8ED7B1B41D1BB03C0053FDBD /* SwitchableCell.m */,
+				8ED7B1B61D1BB04A0053FDBD /* DetailableCell.h */,
+				8ED7B1B71D1BB04A0053FDBD /* DetailableCell.m */,
+			);
+			name = setting;
+			sourceTree = "<group>";
+		};
 		AB00F1D61C71941800689C70 = {
 			isa = PBXGroup;
 			children = (
@@ -573,6 +595,7 @@
 		AB00F3201C71A73D00689C70 /* views */ = {
 			isa = PBXGroup;
 			children = (
+				8ED7B1AF1D1BAFFD0053FDBD /* setting */,
 				8EBB89101D1384990038700B /* top */,
 				AB00F3231C71A7A300689C70 /* webview */,
 				AB00F3221C71A76B00689C70 /* bookmark */,
@@ -935,6 +958,7 @@
 				AB00F2E21C71A29D00689C70 /* GHBookmarkTitleCell.m in Sources */,
 				8EBB89211D13CA960038700B /* TopCollectionHeaderView.m in Sources */,
 				AB00F2E81C71A29D00689C70 /* GHDirectory.m in Sources */,
+				8ED7B1B51D1BB03C0053FDBD /* SwitchableCell.m in Sources */,
 				8EBB89131D1385050038700B /* BookmarkIconViewCell.m in Sources */,
 				AB00F2EC1C71A29D00689C70 /* GHFolderTitleCell.m in Sources */,
 				AB00F4A41C71B16200689C70 /* RATreeNode.m in Sources */,
@@ -949,11 +973,13 @@
 				AB00F4AB1C71B16200689C70 /* RATreeView+TableViewDelegate.m in Sources */,
 				AB00F4AD1C71B16200689C70 /* RATreeView.m in Sources */,
 				AB00F1EA1C71941800689C70 /* ViewController.m in Sources */,
+				8ED7B1B21D1BB0270053FDBD /* GrayLabelCell.m in Sources */,
 				AB00F4A71C71B16200689C70 /* RATreeNodeInfo.m in Sources */,
 				AB00F2E11C71A29D00689C70 /* GHBookmarkCell.m in Sources */,
 				AB00F4A91C71B16200689C70 /* RATreeView+Private.m in Sources */,
 				AB00F49C1C71B16200689C70 /* GTMNSString+HTML.m in Sources */,
 				AB00F2E51C71A29D00689C70 /* GHBookmarkViewController.m in Sources */,
+				8ED7B1B81D1BB04A0053FDBD /* DetailableCell.m in Sources */,
 				AB00F2F61C71A29D00689C70 /* GHToolView.m in Sources */,
 				AB00F1E71C71941800689C70 /* AppDelegate.m in Sources */,
 				8ED7B1AD1D1BA4070053FDBD /* GHSettingViewModel.m in Sources */,

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
@@ -29,15 +29,10 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     //DBの初期値を設定
     [[GHDataManager shareManager] initPrefs];
-    DConnectManager *mgr = [DConnectManager sharedManager];
-    
     NSUserDefaults *def = [NSUserDefaults standardUserDefaults];
-
     BOOL sw = [def boolForKey:IS_FIRST_LAUNCH];
-    BOOL launch = [def boolForKey:IS_MANAGER_LAUNCH];
-    if (!sw || launch) {
-        [mgr startByHttpServer];
-        [def setObject:@(YES) forKey:IS_MANAGER_LAUNCH];
+    if (!sw) {
+        [[DConnectManager sharedManager] startByHttpServer];
         [def setObject:@(YES) forKey:IS_FIRST_LAUNCH];
         [def synchronize];
     
@@ -74,13 +69,7 @@
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
     DConnectManager *mgr = [DConnectManager sharedManager];
-    
-    NSUserDefaults *def = [NSUserDefaults standardUserDefaults];
-    BOOL sw = [def boolForKey:IS_MANAGER_LAUNCH];
-    if (sw) {
-        [mgr startByHttpServer];
-    }
-
+    [mgr startByHttpServer];
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/Base.lproj/Main.storyboard
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/Base.lproj/Main.storyboard
@@ -167,6 +167,7 @@
                                     <barButtonItem image="settings" id="qYV-8V-Mhy">
                                         <connections>
                                             <action selector="openSettingView:" destination="sIh-io-mcp" id="Y9n-Yl-HeB"/>
+                                            <segue destination="Wey-Uj-JCu" kind="presentation" id="LIS-WN-LM7"/>
                                         </connections>
                                     </barButtonItem>
                                     <barButtonItem style="plain" systemItem="flexibleSpace" id="6jv-jC-5iB"/>
@@ -215,6 +216,126 @@
                 </tapGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="1102" y="429"/>
+        </scene>
+        <!--Setting Controller-->
+        <scene sceneID="bDJ-Ty-NW7">
+            <objects>
+                <tableViewController storyboardIdentifier="GHSettingController" id="umo-9H-aLP" customClass="GHSettingController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="18" sectionFooterHeight="18" id="fWx-dC-Tvv">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GrayLabelCell" rowHeight="60" id="xaf-W0-aET" customClass="GrayLabelCell">
+                                <rect key="frame" x="0.0" y="114" width="600" height="60"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xaf-W0-aET" id="jQd-X1-rDn">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="59"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="60" translatesAutoresizingMaskIntoConstraints="NO" id="4og-BE-RjD">
+                                            <rect key="frame" x="20" y="19" width="42" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="4og-BE-RjD" firstAttribute="centerY" secondItem="jQd-X1-rDn" secondAttribute="centerY" id="SHA-DC-tyO"/>
+                                        <constraint firstItem="4og-BE-RjD" firstAttribute="leading" secondItem="jQd-X1-rDn" secondAttribute="leading" constant="20" id="fQJ-tl-0Gt"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="titleLabel" destination="4og-BE-RjD" id="471-Dv-L20"/>
+                                </connections>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="SwitchableCell" rowHeight="60" id="KZx-lh-xyX" customClass="SwitchableCell">
+                                <rect key="frame" x="0.0" y="174" width="600" height="60"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KZx-lh-xyX" id="Ugm-Lg-JBB">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="59"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WmB-F1-oYw">
+                                            <rect key="frame" x="20" y="19" width="42" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gjn-Bs-gfa">
+                                            <rect key="frame" x="536" y="14" width="51" height="31"/>
+                                        </switch>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="WmB-F1-oYw" firstAttribute="leading" secondItem="Ugm-Lg-JBB" secondAttribute="leading" constant="20" id="DIQ-Ws-cJ6"/>
+                                        <constraint firstItem="gjn-Bs-gfa" firstAttribute="centerY" secondItem="Ugm-Lg-JBB" secondAttribute="centerY" id="Fxr-fT-m9W"/>
+                                        <constraint firstItem="WmB-F1-oYw" firstAttribute="centerY" secondItem="Ugm-Lg-JBB" secondAttribute="centerY" id="I0H-FW-Uts"/>
+                                        <constraint firstAttribute="trailing" secondItem="gjn-Bs-gfa" secondAttribute="trailing" constant="15" id="NFx-Vr-dhN"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="switchBtn" destination="gjn-Bs-gfa" id="uPx-a0-z9z"/>
+                                    <outlet property="titleLabel" destination="WmB-F1-oYw" id="nxI-1w-Xr4"/>
+                                </connections>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="DetailableCell" rowHeight="60" id="Qbx-Ki-vih" customClass="DetailableCell">
+                                <rect key="frame" x="0.0" y="234" width="600" height="60"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Qbx-Ki-vih" id="KAM-xC-0Ke">
+                                    <rect key="frame" x="0.0" y="0.0" width="567" height="59"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6pG-6J-PTL">
+                                            <rect key="frame" x="20" y="19" width="42" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="6pG-6J-PTL" firstAttribute="centerY" secondItem="KAM-xC-0Ke" secondAttribute="centerY" id="1g4-Fk-TTP"/>
+                                        <constraint firstItem="6pG-6J-PTL" firstAttribute="leading" secondItem="KAM-xC-0Ke" secondAttribute="leading" constant="20" id="5eI-KD-MvK"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="titleLabel" destination="6pG-6J-PTL" id="pMI-nU-mDq"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="umo-9H-aLP" id="XBZ-KD-AQO"/>
+                            <outlet property="delegate" destination="umo-9H-aLP" id="VVO-nw-oR0"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="8Ql-mS-vA8">
+                        <barButtonItem key="leftBarButtonItem" title="閉じる" id="dD2-cf-2zC">
+                            <connections>
+                                <action selector="close" destination="umo-9H-aLP" id="3Ee-hP-b5j"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="VP6-VL-amR" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2865" y="429"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="gID-BK-chu">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Wey-Uj-JCu" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ezw-Wx-1Sv">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="umo-9H-aLP" kind="relationship" relationship="rootViewController" id="aD2-YH-72M"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="swN-lS-h8s" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2053" y="429"/>
         </scene>
     </scenes>
     <resources>

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
@@ -29,7 +29,6 @@
 @property (strong, nonatomic) UILabel* emptyDevicesLabel;
 
 - (IBAction)openBookmarkView:(id)sender;
-- (IBAction)openSettingView:(id)sender;
 - (IBAction)onTapView:(id)sender;
 
 @end
@@ -153,11 +152,6 @@
     [self presentViewController:bookmark animated:YES completion:nil];
 }
 
-- (IBAction)openSettingView:(id)sender {
-    GHSettingController *setting = [[GHSettingController alloc]initWithStyle:UITableViewStyleGrouped];
-    UINavigationController *nav = [[UINavigationController alloc]initWithRootViewController:setting];
-    [self presentViewController:nav animated:YES completion:nil];
-}
 
 - (IBAction)onTapView:(id)sender {
     [self.view endEditing:YES];

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.h
@@ -1,0 +1,13 @@
+//
+//  DetailableCell.h
+//  dConnectBrowserForIOS9
+//
+//  Created by Tetsuya Hirano on 2016/06/23.
+//  Copyright © 2016年 GClue,Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface DetailableCell : UITableViewCell
+
+@end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.h
@@ -9,5 +9,6 @@
 #import <UIKit/UIKit.h>
 
 @interface DetailableCell : UITableViewCell
-
+@property (weak, nonatomic) IBOutlet UILabel *titleLabel;
+@property (strong, nonatomic) NSIndexPath* indexPath;
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.m
@@ -1,0 +1,13 @@
+//
+//  DetailableCell.m
+//  dConnectBrowserForIOS9
+//
+//  Created by Tetsuya Hirano on 2016/06/23.
+//  Copyright © 2016年 GClue,Inc. All rights reserved.
+//
+
+#import "DetailableCell.h"
+
+@implementation DetailableCell
+
+@end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.m
@@ -9,8 +9,5 @@
 #import "DetailableCell.h"
 
 @implementation DetailableCell
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated
-{
-    [super setSelected:selected animated:animated];
-}
+
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DetailableCell.m
@@ -9,5 +9,8 @@
 #import "DetailableCell.h"
 
 @implementation DetailableCell
-
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated
+{
+    [super setSelected:selected animated:animated];
+}
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -123,7 +123,6 @@
                 case SecurityCellTypeDeleteAccessToken:
                 case SecurityCellTypeOriginWhitelist:
                 case SecurityCellTypeWebSocket:
-                case SecurityCellTypeRESTfulLog:
                     return [self configureDetailCell:tableView atIndexPath: indexPath];
                     break;
                 case SecurityCellTypeOriginBlock:

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -67,7 +67,7 @@
 
 - (void)close
 {
-    [self updateSwitchState];
+    [viewModel updateSwitchState:self.managerSW.isOn blockSW:self.blockSW.isOn];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -77,12 +77,7 @@
 //--------------------------------------------------------------//
 - (void)updateSwitch:(UISwitch*)sender
 {
-    DConnectManager *manager = [DConnectManager sharedManager];
-    if (sender.isOn) {
-        [manager startByHttpServer];
-    } else {
-        [manager stopByHttpServer];
-    }
+    [viewModel updateManager:sender.isOn];
 }
 
 //--------------------------------------------------------------//
@@ -90,19 +85,7 @@
 //--------------------------------------------------------------//
 - (void)updateOriginBlockingSwitch:(UISwitch*)sender
 {
-    [DConnectManager sharedManager].settings.useOriginBlocking = sender.isOn;
-}
-
-///スイッチの状態を保存
-- (void)updateSwitchState
-{
-    NSUserDefaults *def = [NSUserDefaults standardUserDefaults];
-    [def setObject:@(self.managerSW.isOn) forKey:IS_MANAGER_LAUNCH];
-    [def setObject:@(self.blockSW.isOn) forKey:IS_ORIGIN_BLOCKING];
-    [def synchronize];
-    
-    //Cookie許可設定
-    [GHUtils setCookieAccept:self.managerSW.isOn];
+    [viewModel updateOriginBlocking: sender.isOn];
 }
 
 //--------------------------------------------------------------//

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -18,6 +18,25 @@
 @property (nonatomic, strong) UISwitch* blockSW;
 @end
 
+typedef NS_ENUM (NSInteger, SettingCellType) {
+    SettingCellTypeIpAddress,
+    SettingCellTypePortNumber
+};
+
+typedef NS_ENUM (NSInteger, DeviceCellType) {
+    DeviceCellTypeList,
+};
+
+typedef NS_ENUM (NSInteger, SecurityCellType) {
+    SecurityCellTypeDeleteAccessToken,
+    SecurityCellTypeOriginWhitelist,
+    SecurityCellTypeOriginBlock,
+    SecurityCellTypeLocalOAuth,
+    SecurityCellTypeOrigin,
+    SecurityCellTypeExternIP,
+    SecurityCellTypeWebSocket,
+};
+
 
 #define CELL_ID @"setting"
 #define ALERT_COOKIE  100
@@ -33,13 +52,25 @@
 //    NSString *ip = [NSString stringWithFormat:@"Host: %@", [self myIPAddress]];
     self = [super initWithStyle:style];
     if (self) {
-        self.datasource = @[@[@"DeviceConnectManager(ON/OFF)",
-                              @"Port 4035",
-                              @"アクセストークン削除",
-                              @"Originホワイトリスト管理",
-                              @"Originブロック機能"]
+//        self.datasource = @[@[@"DeviceConnectManager(ON/OFF)",
+//                              @"Port 4035",
+//                              @"アクセストークン削除",
+//                              @"Originホワイトリスト管理",
+//                              @"Originブロック機能"]
+//                            ];
+
+        self.datasource = @[@[@(SettingCellTypeIpAddress),
+                              @(SettingCellTypePortNumber)],
+                            @[@(DeviceCellTypeList)],
+                            @[@(SecurityCellTypeDeleteAccessToken),
+                              @(SecurityCellTypeOriginWhitelist),
+                              @(SecurityCellTypeOriginBlock),
+                              @(SecurityCellTypeLocalOAuth),
+                              @(SecurityCellTypeOrigin),
+                              @(SecurityCellTypeExternIP),
+                              @(SecurityCellTypeWebSocket)]
                             ];
-        
+
         self.title = @"設定";
 
     }
@@ -62,15 +93,13 @@
     
     //セルの登録
     [self.tableView registerClass:[UITableViewCell class] forCellReuseIdentifier:CELL_ID];
-    
-//    if (![GHUtils isiPad]) {
-        //ナビボタンのセット
-        UIBarButtonItem* close = [[UIBarButtonItem alloc]initWithTitle:@"閉じる"
-                                                                 style:UIBarButtonItemStylePlain
-                                                                target:self
-                                                                action:@selector(close)];
-        self.navigationItem.leftBarButtonItem = close;
-//    }
+
+    //ナビボタンのセット
+    UIBarButtonItem* close = [[UIBarButtonItem alloc]initWithTitle:@"閉じる"
+                                                             style:UIBarButtonItemStylePlain
+                                                            target:self
+                                                            action:@selector(close)];
+    self.navigationItem.leftBarButtonItem = close;
 }
 
 - (void)didReceiveMemoryWarning

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -10,16 +10,12 @@
 #import "GHSettingController.h"
 #import "GHDataManager.h"
 #import <DConnectSDK/DConnectSDK.h>
-#import <ifaddrs.h>
-#import <arpa/inet.h>
 #import "GHSettingViewModel.h"
 
 @interface GHSettingController ()
 {
     GHSettingViewModel* viewModel;
 }
-
-@property (nonatomic, strong) NSArray* datasource;
 @property (nonatomic, strong) UISwitch* managerSW;
 @property (nonatomic, strong) UISwitch* blockSW;
 @end
@@ -47,7 +43,6 @@
 
 - (void)dealloc
 {
-    self.datasource = nil;
     self.managerSW   = nil;
 }
 
@@ -76,27 +71,7 @@
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (NSString *)myIPAddress
-{
-    NSString *address = nil;
-    struct ifaddrs *interfaces = NULL;
-    struct ifaddrs *temp_addr = NULL;
-    int success = 0;
-    success = getifaddrs(&interfaces);
-    if (success == 0) {
-        temp_addr = interfaces;
-        while(temp_addr != NULL) {
-            if(temp_addr->ifa_addr->sa_family == AF_INET) {
-                if([[NSString stringWithUTF8String:temp_addr->ifa_name] isEqualToString:@"en0"]) {
-                    address = [NSString stringWithUTF8String:inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_addr)->sin_addr)];
-                }
-            }
-            temp_addr = temp_addr->ifa_next;
-        }
-    }
-    freeifaddrs(interfaces);
-    return address;
-}
+
 //--------------------------------------------------------------//
 #pragma mark - ManagerスイッチのON/OFF
 //--------------------------------------------------------------//
@@ -263,8 +238,6 @@
             break;
     }
 }
-
-
 
 
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -12,30 +12,18 @@
 #import <DConnectSDK/DConnectSDK.h>
 #import <ifaddrs.h>
 #import <arpa/inet.h>
+#import "GHSettingViewModel.h"
+
 @interface GHSettingController ()
+{
+    GHSettingViewModel* viewModel;
+}
+
 @property (nonatomic, strong) NSArray* datasource;
 @property (nonatomic, strong) UISwitch* managerSW;
 @property (nonatomic, strong) UISwitch* blockSW;
 @end
 
-typedef NS_ENUM (NSInteger, SettingCellType) {
-    SettingCellTypeIpAddress,
-    SettingCellTypePortNumber
-};
-
-typedef NS_ENUM (NSInteger, DeviceCellType) {
-    DeviceCellTypeList,
-};
-
-typedef NS_ENUM (NSInteger, SecurityCellType) {
-    SecurityCellTypeDeleteAccessToken,
-    SecurityCellTypeOriginWhitelist,
-    SecurityCellTypeOriginBlock,
-    SecurityCellTypeLocalOAuth,
-    SecurityCellTypeOrigin,
-    SecurityCellTypeExternIP,
-    SecurityCellTypeWebSocket,
-};
 
 
 #define CELL_ID @"setting"
@@ -49,30 +37,10 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
 //--------------------------------------------------------------//
 - (id)initWithStyle:(UITableViewStyle)style
 {
-//    NSString *ip = [NSString stringWithFormat:@"Host: %@", [self myIPAddress]];
     self = [super initWithStyle:style];
     if (self) {
-//        self.datasource = @[@[@"DeviceConnectManager(ON/OFF)",
-//                              @"Port 4035",
-//                              @"アクセストークン削除",
-//                              @"Originホワイトリスト管理",
-//                              @"Originブロック機能"]
-//                            ];
-
-        self.datasource = @[@[@(SettingCellTypeIpAddress),
-                              @(SettingCellTypePortNumber)],
-                            @[@(DeviceCellTypeList)],
-                            @[@(SecurityCellTypeDeleteAccessToken),
-                              @(SecurityCellTypeOriginWhitelist),
-                              @(SecurityCellTypeOriginBlock),
-                              @(SecurityCellTypeLocalOAuth),
-                              @(SecurityCellTypeOrigin),
-                              @(SecurityCellTypeExternIP),
-                              @(SecurityCellTypeWebSocket)]
-                            ];
-
+        viewModel = [[GHSettingViewModel alloc]init];
         self.title = @"設定";
-
     }
     return self;
 }
@@ -101,12 +69,6 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
                                                             action:@selector(close)];
     self.navigationItem.leftBarButtonItem = close;
 }
-
-- (void)didReceiveMemoryWarning
-{
-    [super didReceiveMemoryWarning];
-}
-
 
 - (void)close
 {
@@ -174,12 +136,12 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
 {
-    return [self.datasource count];
+    return [viewModel.datasource count];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return [(NSArray *)[self.datasource objectAtIndex:section] count];
+    return [(NSArray *)[viewModel.datasource objectAtIndex:section] count];
 }
 
 
@@ -226,7 +188,7 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
 - (void)configureCell:(UITableViewCell *)cell atIndexPath:(NSIndexPath *)indexPath
 {
     cell.accessoryType = UITableViewCellAccessoryNone;
-    cell.textLabel.text = [[self.datasource objectAtIndex:indexPath.section] objectAtIndex:indexPath.row];
+    cell.textLabel.text = [[viewModel.datasource objectAtIndex:indexPath.section] objectAtIndex:indexPath.row];
     
     if (indexPath.section == 0) {
         switch (indexPath.row) {
@@ -282,6 +244,26 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
         }
     }
 }
+
+
+- (NSString*)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+{
+    switch (section) {
+        case SectionTypeSetting:
+            return @"設定";
+            break;
+        case SectionTypeDevice:
+            return @"デバイスプラグイン";
+            break;
+        case SectionTypeSecurity:
+            return @"セキュリティ";
+            break;
+        default:
+            return @"";
+            break;
+    }
+}
+
 
 
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -22,12 +22,6 @@
 @end
 
 
-
-#define CELL_ID @"setting"
-#define ALERT_COOKIE  100
-#define ALERT_HISTORY 101
-
-
 @implementation GHSettingController
 //--------------------------------------------------------------//
 #pragma mark - 初期化
@@ -68,6 +62,7 @@
 //--------------------------------------------------------------//
 - (void)updateSwitch:(UISwitch*)sender
 {
+    //NOTE: SecurityCellTypeがタグとして設定されている
     SecurityCellType type = sender.tag;
     [viewModel updateSwitch:type switchState:sender.isOn];
 }

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -223,20 +223,7 @@
 
 - (NSString*)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
-    switch (section) {
-        case SectionTypeSetting:
-            return @"設定";
-            break;
-        case SectionTypeDevice:
-            return @"デバイスプラグイン";
-            break;
-        case SectionTypeSecurity:
-            return @"セキュリティ";
-            break;
-        default:
-            return @"";
-            break;
-    }
+    return [viewModel sectionTitle: section];
 }
 
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -162,10 +162,29 @@
     return cell;
 }
 
-- (NSString*)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+CGFloat headerHeight = 36.0;
+- (UIView*)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
-    return [viewModel sectionTitle: section];
+    NSString* title = [viewModel sectionTitle: section];
+    CGRect rect = [[UIScreen mainScreen]bounds];
+    CGFloat screenWidth = rect.size.width;
+    UILabel* label = [[UILabel alloc]initWithFrame:CGRectMake(10, 0, screenWidth, headerHeight)];
+    label.text = title;
+    label.font = [UIFont boldSystemFontOfSize:16.0];
+
+    UIView* header = [[UIView alloc]initWithFrame:CGRectMake(0, 0, screenWidth, headerHeight)];
+    [header addSubview:label];
+    return header;
 }
 
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    return headerHeight;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    return 0;
+}
 
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
@@ -33,13 +33,16 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
     SecurityCellTypeOrigin,
     SecurityCellTypeExternIP,
     SecurityCellTypeWebSocket,
+    SecurityCellTypeRESTfulLog,
 };
 
 @property (nonatomic, strong) NSArray* datasource;
 
 - (NSString*)sectionTitle:(NSInteger)section;
-- (void)updateSwitchState:(BOOL)managerSW blockSW:(BOOL)blockSW;
-- (void)updateManager:(BOOL)isOn;
-- (void)updateOriginBlocking:(BOOL)isOn;
+- (NSString*)cellTitle:(NSIndexPath *)indexPath;
+- (void)updateSwitchState;
+- (void)updateSwitch:(SecurityCellType)type switchState:(BOOL)isOn;
+- (void)didSelectedRow:(NSIndexPath *)indexPath;
+- (BOOL)switchState:(SecurityCellType)type;
 
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
@@ -1,0 +1,40 @@
+//
+//  GHSettingViewModel.h
+//  dConnectBrowserForIOS9
+//
+//  Created by Tetsuya Hirano on 2016/06/23.
+//  Copyright © 2016年 GClue,Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface GHSettingViewModel : NSObject
+
+typedef NS_ENUM (NSInteger, SectionType) {
+    SectionTypeSetting,
+    SectionTypeDevice,
+    SectionTypeSecurity
+};
+
+typedef NS_ENUM (NSInteger, SettingCellType) {
+    SettingCellTypeIpAddress,
+    SettingCellTypePortNumber
+};
+
+typedef NS_ENUM (NSInteger, DeviceCellType) {
+    DeviceCellTypeList,
+};
+
+typedef NS_ENUM (NSInteger, SecurityCellType) {
+    SecurityCellTypeDeleteAccessToken,
+    SecurityCellTypeOriginWhitelist,
+    SecurityCellTypeOriginBlock,
+    SecurityCellTypeLocalOAuth,
+    SecurityCellTypeOrigin,
+    SecurityCellTypeExternIP,
+    SecurityCellTypeWebSocket,
+};
+
+@property (nonatomic, strong) NSArray* datasource;
+
+@end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
@@ -33,7 +33,6 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
     SecurityCellTypeOrigin,
     SecurityCellTypeExternIP,
     SecurityCellTypeWebSocket,
-    SecurityCellTypeRESTfulLog,
 };
 
 @property (nonatomic, strong) NSArray* datasource;

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
@@ -38,5 +38,8 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
 @property (nonatomic, strong) NSArray* datasource;
 
 - (NSString*)sectionTitle:(NSInteger)section;
+- (void)updateSwitchState:(BOOL)managerSW blockSW:(BOOL)blockSW;
+- (void)updateManager:(BOOL)isOn;
+- (void)updateOriginBlocking:(BOOL)isOn;
 
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
@@ -37,4 +37,6 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
 
 @property (nonatomic, strong) NSArray* datasource;
 
+- (NSString*)sectionTitle:(NSInteger)section;
+
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -7,6 +7,7 @@
 //
 
 #import "GHSettingViewModel.h"
+#import <DConnectSDK/DConnectSDK.h>
 #import <ifaddrs.h>
 #import <arpa/inet.h>
 
@@ -71,6 +72,35 @@
             return @"";
             break;
     }
+}
+
+- (void)updateOriginBlocking:(BOOL)isOn
+{
+    [DConnectManager sharedManager].settings.useOriginBlocking = isOn;
+}
+
+//ManagerスイッチのON/OFF
+- (void)updateManager:(BOOL)isOn
+{
+    DConnectManager *manager = [DConnectManager sharedManager];
+    if (isOn) {
+        [manager startByHttpServer];
+    } else {
+        [manager stopByHttpServer];
+    }
+}
+
+
+///スイッチの状態を保存
+- (void)updateSwitchState:(BOOL)managerSW blockSW:(BOOL)blockSW
+{
+    NSUserDefaults *def = [NSUserDefaults standardUserDefaults];
+    [def setObject:@(managerSW) forKey:IS_MANAGER_LAUNCH];
+    [def setObject:@(blockSW) forKey:IS_ORIGIN_BLOCKING];
+    [def synchronize];
+
+    //Cookie許可設定
+    [GHUtils setCookieAccept:managerSW];
 }
 
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -26,8 +26,7 @@
                               @(SecurityCellTypeLocalOAuth),
                               @(SecurityCellTypeOrigin),
                               @(SecurityCellTypeExternIP),
-                              @(SecurityCellTypeWebSocket),
-                              @(SecurityCellTypeRESTfulLog)]
+                              @(SecurityCellTypeWebSocket)]
                             ];
     }
 
@@ -115,9 +114,6 @@
                 case SecurityCellTypeWebSocket:
                     return @"WebSocket一覧";
                     break;
-                case SecurityCellTypeRESTfulLog:
-                    return @"RESTfulリクエストのログ一覧";
-                    break;
             }
             break;
     }
@@ -177,9 +173,6 @@
                     break;
                 case SecurityCellTypeWebSocket:
                     //TODO: WebSocket
-                    break;
-                case SecurityCellTypeRESTfulLog:
-                    //TODO: RESTful log
                     break;
             }
             break;

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -1,0 +1,34 @@
+//
+//  GHSettingViewModel.m
+//  dConnectBrowserForIOS9
+//
+//  Created by Tetsuya Hirano on 2016/06/23.
+//  Copyright © 2016年 GClue,Inc. All rights reserved.
+//
+
+#import "GHSettingViewModel.h"
+
+@implementation GHSettingViewModel
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.datasource = @[@[@(SettingCellTypeIpAddress),
+                              @(SettingCellTypePortNumber)],
+                            @[@(DeviceCellTypeList)],
+                            @[@(SecurityCellTypeDeleteAccessToken),
+                              @(SecurityCellTypeOriginWhitelist),
+                              @(SecurityCellTypeOriginBlock),
+                              @(SecurityCellTypeLocalOAuth),
+                              @(SecurityCellTypeOrigin),
+                              @(SecurityCellTypeExternIP),
+                              @(SecurityCellTypeWebSocket)]
+                            ];
+    }
+
+    return self;
+}
+
+
+@end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -53,4 +53,24 @@
     freeifaddrs(interfaces);
     return address;
 }
+
+
+- (NSString*)sectionTitle:(NSInteger)section
+{
+    switch (section) {
+        case SectionTypeSetting:
+            return @"設定";
+            break;
+        case SectionTypeDevice:
+            return @"デバイスプラグイン";
+            break;
+        case SectionTypeSecurity:
+            return @"セキュリティ";
+            break;
+        default:
+            return @"";
+            break;
+    }
+}
+
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -74,33 +74,141 @@
     }
 }
 
-- (void)updateOriginBlocking:(BOOL)isOn
+- (NSString*)cellTitle:(NSIndexPath *)indexPath
 {
-    [DConnectManager sharedManager].settings.useOriginBlocking = isOn;
+    NSInteger type = [(NSNumber*)[[self.datasource objectAtIndex:indexPath.section] objectAtIndex:indexPath.row] integerValue];
+    switch (indexPath.section) {
+        case SectionTypeSetting:
+            switch (type) {
+                case SettingCellTypeIpAddress:
+                    return [NSString stringWithFormat: @"IP %@", [self myIPAddress]];
+                    break;
+                case SettingCellTypePortNumber:
+                    return @"Port 4035";
+                    break;
+            }
+            break;
+        case SectionTypeDevice:
+            return @"デバイスプラグイン";
+            break;
+        case SectionTypeSecurity:
+            switch (type) {
+                case SecurityCellTypeDeleteAccessToken:
+                    return @"アクセストークン削除";
+                    break;
+                case SecurityCellTypeOriginWhitelist:
+                    return @"Originホワイトリスト管理";
+                    break;
+                case SecurityCellTypeOriginBlock:
+                    return @"Originブロック機能";
+                    break;
+                case SecurityCellTypeLocalOAuth:
+                    return @"LocalAuth (ON/OFF)";
+                    break;
+                case SecurityCellTypeOrigin:
+                    return @"Origin (有効/無効)";
+                    break;
+                case SecurityCellTypeExternIP:
+                    return @"外部IPを許可 (有効/無効)";
+                    break;
+                case SecurityCellTypeWebSocket:
+                    return @"WebSocket一覧";
+                    break;
+                case SecurityCellTypeRESTfulLog:
+                    return @"RESTfulリクエストのログ一覧";
+                    break;
+            }
+            break;
+    }
+
+    return @"";
 }
 
-//ManagerスイッチのON/OFF
-- (void)updateManager:(BOOL)isOn
+
+- (void)updateSwitch:(SecurityCellType)type switchState:(BOOL)isOn
 {
-    DConnectManager *manager = [DConnectManager sharedManager];
-    if (isOn) {
-        [manager startByHttpServer];
-    } else {
-        [manager stopByHttpServer];
+    switch (type) {
+        case SecurityCellTypeOriginBlock:
+            [DConnectManager sharedManager].settings.useOriginBlocking = isOn;
+            break;
+        case SecurityCellTypeLocalOAuth:
+            [DConnectManager sharedManager].settings.useLocalOAuth = isOn;
+            break;
+        case SecurityCellTypeOrigin:
+            //TODO:
+            break;
+        case SecurityCellTypeExternIP:
+            //TODO:
+            break;
+        case SecurityCellTypeWebSocket:
+            //TODO:
+            break;
+        default:
+            break;
     }
 }
 
 
 ///スイッチの状態を保存
-- (void)updateSwitchState:(BOOL)managerSW blockSW:(BOOL)blockSW
+- (void)updateSwitchState
 {
     NSUserDefaults *def = [NSUserDefaults standardUserDefaults];
-    [def setObject:@(managerSW) forKey:IS_MANAGER_LAUNCH];
-    [def setObject:@(blockSW) forKey:IS_ORIGIN_BLOCKING];
+    DConnectSettings* settings = [DConnectManager sharedManager].settings;
+    [def setObject:@(settings.useOriginBlocking) forKey:IS_ORIGIN_BLOCKING];
+    [def setObject:@(settings.useLocalOAuth) forKey:IS_USE_LOCALOAUTH];
     [def synchronize];
+}
 
-    //Cookie許可設定
-    [GHUtils setCookieAccept:managerSW];
+- (void)didSelectedRow:(NSIndexPath *)indexPath
+{
+    NSInteger type = [(NSNumber*)[[self.datasource objectAtIndex:indexPath.section] objectAtIndex:indexPath.row] integerValue];
+    switch (indexPath.section) {
+        case SectionTypeDevice:
+            //TODO: DeviceList
+            break;
+        case SectionTypeSecurity:
+            switch (type) {
+                case SecurityCellTypeDeleteAccessToken:
+                    [DConnectUtil showAccessTokenList];
+                    break;
+                case SecurityCellTypeOriginWhitelist:
+                    [DConnectUtil showOriginWhitelist];
+                    break;
+                case SecurityCellTypeWebSocket:
+                    //TODO: WebSocket
+                    break;
+                case SecurityCellTypeRESTfulLog:
+                    //TODO: RESTful log
+                    break;
+            }
+            break;
+    }
+}
+
+
+- (BOOL)switchState:(SecurityCellType)type
+{
+    switch (type) {
+        case SecurityCellTypeOriginBlock:
+            return [DConnectManager sharedManager].settings.useOriginBlocking;
+            break;
+        case SecurityCellTypeLocalOAuth:
+            return [DConnectManager sharedManager].settings.useLocalOAuth;
+            break;
+        case SecurityCellTypeOrigin:
+            //TODO:
+            break;
+        case SecurityCellTypeExternIP:
+            //TODO:
+            break;
+        case SecurityCellTypeWebSocket:
+            //TODO:
+            break;
+        default:
+            return NO;
+            break;
+    }
+    return NO; //FIXME:
 }
 
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -7,6 +7,8 @@
 //
 
 #import "GHSettingViewModel.h"
+#import <ifaddrs.h>
+#import <arpa/inet.h>
 
 @implementation GHSettingViewModel
 
@@ -30,5 +32,25 @@
     return self;
 }
 
-
+- (NSString *)myIPAddress
+{
+    NSString *address = nil;
+    struct ifaddrs *interfaces = NULL;
+    struct ifaddrs *temp_addr = NULL;
+    int success = 0;
+    success = getifaddrs(&interfaces);
+    if (success == 0) {
+        temp_addr = interfaces;
+        while(temp_addr != NULL) {
+            if(temp_addr->ifa_addr->sa_family == AF_INET) {
+                if([[NSString stringWithUTF8String:temp_addr->ifa_name] isEqualToString:@"en0"]) {
+                    address = [NSString stringWithUTF8String:inet_ntoa(((struct sockaddr_in *)temp_addr->ifa_addr)->sin_addr)];
+                }
+            }
+            temp_addr = temp_addr->ifa_next;
+        }
+    }
+    freeifaddrs(interfaces);
+    return address;
+}
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -26,7 +26,8 @@
                               @(SecurityCellTypeLocalOAuth),
                               @(SecurityCellTypeOrigin),
                               @(SecurityCellTypeExternIP),
-                              @(SecurityCellTypeWebSocket)]
+                              @(SecurityCellTypeWebSocket),
+                              @(SecurityCellTypeRESTfulLog)]
                             ];
     }
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.h
@@ -1,0 +1,13 @@
+//
+//  GrayLabelCell.h
+//  dConnectBrowserForIOS9
+//
+//  Created by Tetsuya Hirano on 2016/06/23.
+//  Copyright © 2016年 GClue,Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface GrayLabelCell : UITableViewCell
+
+@end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.h
@@ -9,5 +9,6 @@
 #import <UIKit/UIKit.h>
 
 @interface GrayLabelCell : UITableViewCell
+@property (weak, nonatomic) IBOutlet UILabel *titleLabel;
 
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.m
@@ -10,8 +10,4 @@
 
 @implementation GrayLabelCell
 
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated
-{
-    [super setSelected:selected animated:animated];
-}
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.m
@@ -1,0 +1,13 @@
+//
+//  GrayLabelCell.m
+//  dConnectBrowserForIOS9
+//
+//  Created by Tetsuya Hirano on 2016/06/23.
+//  Copyright © 2016年 GClue,Inc. All rights reserved.
+//
+
+#import "GrayLabelCell.h"
+
+@implementation GrayLabelCell
+
+@end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GrayLabelCell.m
@@ -10,4 +10,8 @@
 
 @implementation GrayLabelCell
 
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated
+{
+    [super setSelected:selected animated:animated];
+}
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.h
@@ -9,5 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @interface SwitchableCell : UITableViewCell
-
+@property (weak, nonatomic) IBOutlet UILabel *titleLabel;
+@property (weak, nonatomic) IBOutlet UISwitch *switchBtn;
+@property (strong, nonatomic) NSIndexPath* indexPath;
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.h
@@ -1,0 +1,13 @@
+//
+//  SwitchableCell.h
+//  dConnectBrowserForIOS9
+//
+//  Created by Tetsuya Hirano on 2016/06/23.
+//  Copyright © 2016年 GClue,Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface SwitchableCell : UITableViewCell
+
+@end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.m
@@ -1,0 +1,13 @@
+//
+//  SwitchableCell.m
+//  dConnectBrowserForIOS9
+//
+//  Created by Tetsuya Hirano on 2016/06/23.
+//  Copyright © 2016年 GClue,Inc. All rights reserved.
+//
+
+#import "SwitchableCell.h"
+
+@implementation SwitchableCell
+
+@end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.m
@@ -9,14 +9,5 @@
 #import "SwitchableCell.h"
 
 @implementation SwitchableCell
-- (void)awakeFromNib
-{
-    [super awakeFromNib];
-    self.selectionStyle = UITableViewCellSelectionStyleNone;
-}
 
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated
-{
-    [super setSelected:selected animated:animated];
-}
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/SwitchableCell.m
@@ -9,5 +9,14 @@
 #import "SwitchableCell.h"
 
 @implementation SwitchableCell
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    self.selectionStyle = UITableViewCellSelectionStyleNone;
+}
 
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated
+{
+    [super setSelected:selected animated:animated];
+}
 @end


### PR DESCRIPTION
## Why

設定画面の機能追加
- ManagerのON/OFFを削除(フォアグラウンド時、常にON)。
- 外部からアクセスされるときのために、IPの項目を追加。
- IPとPortは編集できない。
- デバイスプラグインの設定画面一覧を表示する項目を追加。
- Android側にあわせて、以下の項目を追加。
  - 外部IPの有効・無効。
  - Originの有効・無効。
  - LocalOAuthの有効・無効。
  - 現在接続されているWebSocketの一覧の表示。
  - 受け付けたRESTfulリクエストのログ一覧の表示。
## Works
- GHSettingViewModelを新規に追加。GHSettingViewControllerで保持していたロジックを部を移行。
- GHSettingViewControllerをstoryboardを使用するように変更。
- GrayLabelCell, DetailableCell, SwitchableCellを新規に追加。
- DConnectManagerのオンオフ設定保存を削除。常にオンにする。
