### PR TITLE
BrowserをタスクキルしたときにManagerが起動しない件の修正。

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
@@ -46,6 +46,9 @@
                                                                                    categories:nil];
         [application registerUserNotificationSettings:mySettings];
     }
+    DConnectManager *mgr = [DConnectManager sharedManager];
+    [mgr startByHttpServer];
+
     return YES;
 }
 


### PR DESCRIPTION
- ローカルサーバでdemoWebSiteを見れるようにし、dConnectBrowserでdemoWebSiteへアクセスできるようにする。
- ホームボタンを押して、ホーム画面に戻る。
- ホームボタンを2回押して、タスク一覧を出す。
- タスクの中から、dConnectBrowserを終了する。
- 再び、dConnectBrowserを起動し、demoWebSiteへアクセスする。
- DeviceConnect関連のAPIが操作できなくなっている。
