### PR TITLE
iPadでTop画面を横回転した際ステータスバーが検索バーにめり込んでしまう不具合の修正

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
@@ -103,6 +103,11 @@
                                 duration:(NSTimeInterval)duration
 {
     [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
+
+    if ([[UIDevice currentDevice]userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+        return;
+    }
+
     if ((toInterfaceOrientation == UIDeviceOrientationLandscapeLeft ||
          toInterfaceOrientation == UIDeviceOrientationLandscapeRight))
     {


### PR DESCRIPTION
## Why

iPadでTop画面を横回転した際ステータスバーが検索バーにめり込んでしまう不具合の修正
## Works
- iPadの時はナビゲーションバーを短くしないように修正。
