### PR TITLE
設定画面からWesocket一覧を削除

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -53,11 +53,6 @@
     [self presentViewController:nav animated:YES completion:nil];
 }
 
-- (void)openWebSocketList
-{
-
-}
-
 //--------------------------------------------------------------//
 #pragma mark - view cycle
 //--------------------------------------------------------------//
@@ -112,7 +107,7 @@
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return 60;
+    return 50;
 }
 
 /**
@@ -139,7 +134,6 @@
             switch (type) {
                 case SecurityCellTypeDeleteAccessToken:
                 case SecurityCellTypeOriginWhitelist:
-                case SecurityCellTypeWebSocket:
                     return [self configureDetailCell:tableView atIndexPath: indexPath];
                     break;
                 case SecurityCellTypeOriginBlock:

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
@@ -10,7 +10,6 @@
 
 @protocol GHSettingViewModelDelegate <NSObject>
 - (void)openDevicePluginList;
-- (void)openWebSocketList;
 @end
 
 @interface GHSettingViewModel : NSObject
@@ -37,7 +36,6 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
     SecurityCellTypeLocalOAuth,
     SecurityCellTypeOrigin,
     SecurityCellTypeExternIP,
-    SecurityCellTypeWebSocket,
 };
 
 @property (nonatomic, strong) NSArray* datasource;

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -26,8 +26,7 @@
                               @(SecurityCellTypeOriginBlock),
                               @(SecurityCellTypeLocalOAuth),
                               @(SecurityCellTypeOrigin),
-                              @(SecurityCellTypeExternIP),
-                              @(SecurityCellTypeWebSocket)]
+                              @(SecurityCellTypeExternIP)]
                             ];
     }
 
@@ -112,9 +111,6 @@
                 case SecurityCellTypeExternIP:
                     return @"外部IPを許可 (有効/無効)";
                     break;
-                case SecurityCellTypeWebSocket:
-                    return @"WebSocket一覧";
-                    break;
             }
             break;
     }
@@ -136,9 +132,6 @@
             //TODO:
             break;
         case SecurityCellTypeExternIP:
-            //TODO:
-            break;
-        case SecurityCellTypeWebSocket:
             //TODO:
             break;
         default:
@@ -172,9 +165,6 @@
                 case SecurityCellTypeOriginWhitelist:
                     [DConnectUtil showOriginWhitelist];
                     break;
-                case SecurityCellTypeWebSocket:
-                    [self.delegate openWebSocketList];
-                    break;
             }
             break;
     }
@@ -194,9 +184,6 @@
             //TODO:
             break;
         case SecurityCellTypeExternIP:
-            //TODO:
-            break;
-        case SecurityCellTypeWebSocket:
             //TODO:
             break;
         default:


### PR DESCRIPTION
## Why

仕様変更により設定画面からWesocket一覧を削除
## Works
- SecurityCellType ENUMからSecurityCellTypeWebSocketを削除
- viewModelで保持しているdatasourceからSecurityCellTypeWebSocketを削除
