### PR TITLE
SafariViewControllerからブックマーク登録時に2度表示されている

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
@@ -82,11 +82,13 @@
 - (void)applicationWillTerminate:(UIApplication *)application {
     [[GHDataManager shareManager]save];
 }
-- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation
+
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options
 {
     if (![url.scheme isEqualToString:@"dconnect"] && ![url.scheme isEqualToString:@"gotapi"]) {
         return NO;
     }
+
     NSString *directURLStr = [url.resourceSpecifier stringByRemovingPercentEncoding];
     NSURL *redirectURL = [NSURL URLWithString:directURLStr];
     if (_URLLoadingCallback && redirectURL) {

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
@@ -85,7 +85,9 @@
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options
 {
-    if (![url.scheme isEqualToString:@"dconnect"] && ![url.scheme isEqualToString:@"gotapi"]) {
+    //NOTE:safariViewからのリダイレクトは無視する(つまりBookmarkShare)
+    NSString* value =  options[@"UIApplicationOpenURLOptionsSourceApplicationKey"];
+    if ((![url.scheme isEqualToString:@"dconnect"] && ![url.scheme isEqualToString:@"gotapi"]) || [value isEqualToString:@"com.apple.SafariViewService"]) {
         return NO;
     }
 


### PR DESCRIPTION
## Why

SafariViewControllerからブックマーク登録時に2度表示されている
## 原因

SafariViewControllerからBookmarkShareを使った場合、
`- application:openURL:sourceApplication:annotation:`が呼ばれてリダイレクトが走っていたためにSafariViewControllerが2度表示されていた。
## Works
- deprecatedになった`- application:openURL:sourceApplication:annotation:`を`- application:openURL:options:`に書き換え
- `- application:openURL:options:`がコールされた場合でoptionsの`UIApplicationOpenURLOptionsSourceApplicationKey`が`com.apple.SafariViewService`の場合はリダイレクトさせない処理を追加
