### PR TITLE
URLスキームによる起動・終了の実装

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHURLManager.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHURLManager.m
@@ -76,8 +76,13 @@
 
 
 ///google検索APIの形式にする
+///strが'//start'または'//stop'の場合はgoogleトップを表示する
 - (NSString*)createSearchURL:(NSString*)str
 {
+    if ([str isEqualToString:@"//start"] || [str isEqualToString:@"//stop"]) {
+        return @"https://google.co.jp";
+    }
+
     NSArray *languages = [NSLocale preferredLanguages];
     NSString *lang = [languages objectAtIndex:0];
     NSString *encodedString = [str stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.h
@@ -12,9 +12,10 @@
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
-@property NSURL *redirectURL;
+@property (strong, nonatomic) NSURL *redirectURL;
+@property (strong, nonatomic) NSURL* latestURL;
 @property (copy) void(^URLLoadingCallback)(NSURL *);
-
+@property (copy) void(^requestToCloseSafariView)();
 
 @end
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
@@ -103,7 +103,7 @@
 
     //NOTE:BookmarkShareからのリダイレクトは無視する
     if ((![url.scheme isEqualToString:@"dconnect"] && ![url.scheme isEqualToString:@"gotapi"]) ||
-        ([value isEqualToString:@"com.apple.SafariViewService"] && ![url.absoluteString isEqualToString:@"gotapi://stop"])) {
+        [value isEqualToString:@"com.apple.SafariViewService"]) {
         return NO;
     }
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
@@ -93,9 +93,11 @@
     //safariViewからgotapi://stopが叩かれた場合
     NSString* value =  options[@"UIApplicationOpenURLOptionsSourceApplicationKey"];
     if ([value isEqualToString:@"com.apple.SafariViewService"] && [url.absoluteString isEqualToString:@"gotapi://stop"]) {
-        dispatch_async(dispatch_get_main_queue() , ^{
-            [[UIApplication sharedApplication] openURL: self.latestURL];
-            _requestToCloseSafariView();
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) , ^{
+            dispatch_async(dispatch_get_main_queue() , ^{
+                [[UIApplication sharedApplication] openURL: self.latestURL];
+                _requestToCloseSafariView();
+            });
         });
         return NO;
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/AppDelegate.m
@@ -90,9 +90,20 @@
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options
 {
-    //NOTE:safariViewからのリダイレクトは無視する(つまりBookmarkShare)
+    //safariViewからgotapi://stopが叩かれた場合
     NSString* value =  options[@"UIApplicationOpenURLOptionsSourceApplicationKey"];
-    if ((![url.scheme isEqualToString:@"dconnect"] && ![url.scheme isEqualToString:@"gotapi"]) || [value isEqualToString:@"com.apple.SafariViewService"]) {
+    if ([value isEqualToString:@"com.apple.SafariViewService"] && [url.absoluteString isEqualToString:@"gotapi://stop"]) {
+        dispatch_async(dispatch_get_main_queue() , ^{
+            [[UIApplication sharedApplication] openURL: self.latestURL];
+            _requestToCloseSafariView();
+        });
+        return NO;
+
+    }
+
+    //NOTE:BookmarkShareからのリダイレクトは無視する
+    if ((![url.scheme isEqualToString:@"dconnect"] && ![url.scheme isEqualToString:@"gotapi"]) ||
+        ([value isEqualToString:@"com.apple.SafariViewService"] && ![url.absoluteString isEqualToString:@"gotapi://stop"])) {
         return NO;
     }
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
@@ -60,6 +60,11 @@
                  [self openSafariViewInternalWithURL:redirectURL.absoluteString];
              }
          }];
+        [(AppDelegate *)appDelegate setRequestToCloseSafariView:^{
+            if (appDelegate.window.rootViewController.presentedViewController != nil) {
+                [self dismissViewControllerAnimated:false completion:nil];
+            }
+        }];
     }
 
     [super viewDidLoad];

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/TopViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/TopViewModel.m
@@ -10,6 +10,7 @@
 #import <DConnectSDK/DConnectSDK.h>
 #import "GHDataManager.h"
 #import "GHDeviceUtil.h"
+#import "AppDelegate.h"
 
 @interface TopViewModel()
 @property(nonatomic, strong) NSArray* devices;
@@ -180,6 +181,7 @@ static NSInteger maxIconCount = 8;
     } else if (!self.url) {
         self.url = [self.manager createSearchURL:url];
     }
+    [self setLatestURL:self.url];
     return self.url;
 }
 
@@ -194,8 +196,17 @@ static NSInteger maxIconCount = 8;
     } else if (![self.manager isURLString:self.url]) {
         self.url = [self.manager createSearchURL:url];
     }
+
+    [self setLatestURL:self.url];
     return self.url;
 }
+
+- (void)setLatestURL:(NSString*)url
+{
+    AppDelegate* app = [UIApplication sharedApplication].delegate;
+    app.latestURL = [NSURL URLWithString: url];
+}
+
 
 
 //--------------------------------------------------------------//

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Dependencies/RoutingHTTPServer/RoutingConnection.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Dependencies/RoutingHTTPServer/RoutingConnection.m
@@ -12,7 +12,7 @@
 	if (self = [super initWithAsyncSocket:newSocket configuration:aConfig]) {
 		NSAssert([config.server isKindOfClass:[RoutingHTTPServer class]],
 				 @"A RoutingConnection is being used with a server that is not a RoutingHTTPServer");
-
+        
 		http = (RoutingHTTPServer *)config.server;
 	}
 	return self;
@@ -88,16 +88,15 @@
 }
 
 - (void)setHeadersForResponse:(HTTPMessage *)response isError:(BOOL)isError {
-	[http.defaultHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL *stop) {
-		[response setHeaderField:field value:value];
-	}];
+//	[http.defaultHeaders enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL *stop) {
+//		[response setHeaderField:field value:value];
+//	}];
 
 	if (headers && !isError) {
 		[headers enumerateKeysAndObjectsUsingBlock:^(id field, id value, BOOL *stop) {
 			[response setHeaderField:field value:value];
 		}];
 	}
-
 	// Set the connection header if not already specified
 	NSString *connection = [response headerField:@"Connection"];
 	if (!connection) {


### PR DESCRIPTION
## Why

URLスキームによる起動・終了の実装
## Works
- gotapi://start'または'gotapi://stop'の場合はgoogleトップを表示する処理を追加
- safariViewControllerからgotapi://stopが呼ばれた際のmobile safariを開く処理を追加
- 開いているurlの保持を実装
