### PR TITLE
デバイス一覧画面のアイコンが反転したまま戻らないバグの修正

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/Base.lproj/Main.storyboard
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="sIh-io-mcp">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="sIh-io-mcp">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
@@ -41,6 +41,7 @@
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aD8-rK-ltM">
                                                     <rect key="frame" x="0.0" y="0.0" width="70" height="75"/>
                                                     <connections>
+                                                        <action selector="backNormal:" destination="mxe-B7-ksr" eventType="touchDragOutside" id="HiX-5O-cPG"/>
                                                         <action selector="backNormal:" destination="mxe-B7-ksr" eventType="touchCancel" id="VPt-s2-5uz"/>
                                                         <action selector="didTapItem:" destination="mxe-B7-ksr" eventType="touchUpInside" id="Bab-mh-81M"/>
                                                         <action selector="didTouchDown:" destination="mxe-B7-ksr" eventType="touchDown" id="pFf-S0-PIK"/>
@@ -102,6 +103,7 @@
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cuk-KV-3vZ">
                                                     <rect key="frame" x="0.0" y="0.0" width="70" height="75"/>
                                                     <connections>
+                                                        <action selector="backNormal:" destination="PaE-c0-nDI" eventType="touchDragOutside" id="G9O-3V-MUA"/>
                                                         <action selector="backNormal:" destination="PaE-c0-nDI" eventType="touchCancel" id="aSL-Ws-i1j"/>
                                                         <action selector="didTapItem:" destination="PaE-c0-nDI" eventType="touchUpInside" id="GYd-Av-KYC"/>
                                                         <action selector="didTouchDown:" destination="PaE-c0-nDI" eventType="touchDown" id="UeN-vZ-ySF"/>

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DeviceIconViewCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DeviceIconViewCell.m
@@ -56,9 +56,12 @@
 }
 
 - (IBAction)didTouchDown:(UIButton *)sender {
-    [UIView animateWithDuration:0.15 animations:^{
-        self.alpha = 0.3;
-    }];
+    
+    __weak DeviceIconViewCell* _self = self;
+    self.alpha = 0.3;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        _self.alpha = 1.0;
+    });
 }
 
 - (IBAction)backNormal:(UIButton *)sender {

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DeviceIconViewCell.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/DeviceIconViewCell.m
@@ -56,12 +56,9 @@
 }
 
 - (IBAction)didTouchDown:(UIButton *)sender {
-    
-    __weak DeviceIconViewCell* _self = self;
-    self.alpha = 0.3;
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        _self.alpha = 1.0;
-    });
+    [UIView animateWithDuration:0.15 animations:^{
+        self.alpha = 0.3;
+    }];
 }
 
 - (IBAction)backNormal:(UIButton *)sender {


### PR DESCRIPTION
# 手順
1. デバイス一覧画面のアイコンをタッチする。
2. タッチしたまま、アイコンの外まで指を移動する。
3. その位置で指を離す。
4. アイコンが反転したまま戻らない。
