### PR TITLE
[iOS]TOP画面のブックマーク一覧から#を含んだページに遷移するとNotFoundになる

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHURLManager.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/BookmarkDBFramework/GHURLManager.m
@@ -58,7 +58,7 @@
         if ([result resultType] == NSTextCheckingTypeLink) {
             NSURL *url = [result URL];
             if ([[url scheme] isEqualToString: @"http"] || [[url scheme] isEqualToString: @"https"]) {
-                return [url description];
+                return str;
             } else if ([[url scheme] isEqualToString: @"gotapi"] && [[url host] isEqualToString: @"start"]) {
                 //gotapiの場合
                 NSString* queryURL = @"url=";

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/ViewController.m
@@ -202,7 +202,7 @@
         sfSafariViewController.delegate = self;
         [self presentViewController:sfSafariViewController animated:YES completion:nil];
     };
-    loadSFSafariViewControllerBlock([NSURL URLWithString: [viewModel checkUrlString:url]]);
+    loadSFSafariViewControllerBlock([NSURL URLWithString: [viewModel checkUrlString:url].stringByRemovingPercentEncoding]);
 }
 
 - (void)openInitialGuide


### PR DESCRIPTION
# Why

[iOS]TOP画面のブックマーク一覧から#を含んだページに遷移するとNotFoundになる
# Work
- #を削除していたので、urlと判定できた場合は削除前の文字列をそのまま返却するように修正。
- urlEncodeされたurlを元に戻してからsafariViewへ渡す
