### PR TITLE
ブラウザのアドレスバーにスキーム名のないURLを入力すると強制終了する問題の修正

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/TopViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/TopViewModel.m
@@ -183,6 +183,11 @@ static NSInteger maxIconCount = 8;
     } else if (!self.url) {
         self.url = [self.manager createSearchURL:url];
     }
+    // http:// https://が省略されているときは付加する
+    if (![[self.url lowercaseString] hasPrefix:@"http://"]
+        && ![[self.url lowercaseString] hasPrefix:@"https://"]) {
+        self.url = [NSString stringWithFormat:@"http://%@", self.url];
+    }
     [self setLatestURL:self.url];
     return self.url;
 }


### PR DESCRIPTION
URLにhttp://https://が省略されている場合は、付加するようにした。
