### PR TITLE
DeviceConnectのリクエストをGETで操作

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest.xcodeproj/project.pbxproj
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		AB043C931BDF6B4000B35D96 /* TestLightProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = AB043C921BDF6B3F00B35D96 /* TestLightProfile.m */; };
 		AB81AC881BDF7C250069F6EB /* RESTfulFailLightProfileTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AB81AC871BDF7C250069F6EB /* RESTfulFailLightProfileTest.m */; };
 		ABF1B0981E3CC7B90033B059 /* dConnectDeviceTestTests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 309CD533198B2CCF002A5684 /* dConnectDeviceTestTests-Info.plist */; };
+		ABF1B09B1E3CD8B30033B059 /* TestAllGetControlProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = ABF1B09A1E3CD8B30033B059 /* TestAllGetControlProfile.m */; };
+		ABF1B09D1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m in Sources */ = {isa = PBXBuildFile; fileRef = ABF1B09C1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m */; };
 		ABF842BC19E3E07300B8AC46 /* DConnectSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABF842BB19E3E07300B8AC46 /* DConnectSDK.framework */; };
 		D63350C11D6C3E2600CB9E5A /* TestService.m in Sources */ = {isa = PBXBuildFile; fileRef = D63350C01D6C3E2600CB9E5A /* TestService.m */; };
 		D646EDC71D6D1AEE0092CBA7 /* TestDriveControllerProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = D646EDC61D6D1AEE0092CBA7 /* TestDriveControllerProfile.m */; };
@@ -270,6 +272,9 @@
 		AB043C921BDF6B3F00B35D96 /* TestLightProfile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestLightProfile.m; sourceTree = "<group>"; };
 		AB67AAD11C637A6400B4C62C /* Pods.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Pods.xcodeproj; path = ../../../../../sample/SFSafariViewController/pod/Pods/Pods.xcodeproj; sourceTree = "<group>"; };
 		AB81AC871BDF7C250069F6EB /* RESTfulFailLightProfileTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RESTfulFailLightProfileTest.m; path = dConnectManager/RESTful/RESTfulFailLightProfileTest.m; sourceTree = "<group>"; };
+		ABF1B0991E3CD8B30033B059 /* TestAllGetControlProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestAllGetControlProfile.h; sourceTree = "<group>"; };
+		ABF1B09A1E3CD8B30033B059 /* TestAllGetControlProfile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestAllGetControlProfile.m; sourceTree = "<group>"; };
+		ABF1B09C1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RESTfulNormalAllGetControlTest.m; path = dConnectManager/RESTful/RESTfulNormalAllGetControlTest.m; sourceTree = "<group>"; };
 		ABF842BB19E3E07300B8AC46 /* DConnectSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DConnectSDK.framework; path = ../../dConnectSDK/dConnectSDKForIOS/bin/DConnectSDK.framework; sourceTree = "<group>"; };
 		D63350BF1D6C3E2600CB9E5A /* TestService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestService.h; sourceTree = "<group>"; };
 		D63350C01D6C3E2600CB9E5A /* TestService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestService.m; sourceTree = "<group>"; };
@@ -458,6 +463,8 @@
 				84FA975A19A5F1DE0053B2FD /* TestUniqueTimeoutProfile.m */,
 				847B3B1C19BD7A3A003ED5F4 /* TestUniqueEventProfile.h */,
 				847B3B1D19BD7A3A003ED5F4 /* TestUniqueEventProfile.m */,
+				ABF1B0991E3CD8B30033B059 /* TestAllGetControlProfile.h */,
+				ABF1B09A1E3CD8B30033B059 /* TestAllGetControlProfile.m */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -518,6 +525,7 @@
 				AB81AC871BDF7C250069F6EB /* RESTfulFailLightProfileTest.m */,
 				6BD1F6F11A9EC6B2005956F5 /* RESTfulFailServiceInformationProfileTest.m */,
 				84FA976019A615400053B2FD /* RESTfulFailVibrationProfileTest.m */,
+				ABF1B09C1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m */,
 			);
 			name = RESTful;
 			sourceTree = "<group>";
@@ -770,6 +778,7 @@
 				847B3B1E19BD7A3A003ED5F4 /* TestUniqueEventProfile.m in Sources */,
 				D63350C11D6C3E2600CB9E5A /* TestService.m in Sources */,
 				84FA975819A5D3580053B2FD /* TestUniquePingProfile.m in Sources */,
+				ABF1B09B1E3CD8B30033B059 /* TestAllGetControlProfile.m in Sources */,
 				301B89BA198F7799006EC109 /* TestNotificationProfile.m in Sources */,
 				301B89C0198F848F006EC109 /* TestProximityProfile.m in Sources */,
 				309CD55F198F2F7A002A5684 /* TestDeviceOrientationProfile.m in Sources */,
@@ -795,6 +804,7 @@
 				8428954419A2002500D9ECFF /* RESTfulNormalProximityProfileTest.m in Sources */,
 				8490A34F19A488350031FD1E /* RESTfulFailSystemProfileTest.m in Sources */,
 				8428953F19A2002500D9ECFF /* RESTfulNormalFileProfileTest.m in Sources */,
+				ABF1B09D1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m in Sources */,
 				8428954219A2002500D9ECFF /* RESTfulNormalNotificationProfileTest.m in Sources */,
 				8428954519A2002500D9ECFF /* RESTfulNormalSettingsProfileTest.m in Sources */,
 				8490A35019A488350031FD1E /* RESTfulFailNetworkServiceDiscoveryProfileTest.m in Sources */,

--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest.xcodeproj/project.pbxproj
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest.xcodeproj/project.pbxproj
@@ -92,10 +92,7 @@
 		84EBE7D419B5CB1B0089AD35 /* RESTfulNormalAuthorizationProfileTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 84EBE7D319B5CB1B0089AD35 /* RESTfulNormalAuthorizationProfileTest.m */; };
 		84EBE7D719B5E2340089AD35 /* AccessToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 84EBE7D619B5E2340089AD35 /* AccessToken.m */; };
 		84EBE8EE19B88BFB0089AD35 /* RESTfulFailAuthorizationProfileTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 84EBE8ED19B88BFB0089AD35 /* RESTfulFailAuthorizationProfileTest.m */; };
-		84FA974D19A4CF430053B2FD /* RESTfulStressTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FA974C19A4CF430053B2FD /* RESTfulStressTest.m */; };
 		84FA974F19A5942E0053B2FD /* RESTfulFailBatteryProfileTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FA974E19A5942E0053B2FD /* RESTfulFailBatteryProfileTest.m */; };
-		84FA975219A59CBD0053B2FD /* RESTfulFailCommonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FA975119A59CBD0053B2FD /* RESTfulFailCommonTest.m */; };
-		84FA975519A5C8850053B2FD /* RESTfulNormalCommonTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FA975419A5C8850053B2FD /* RESTfulNormalCommonTest.m */; };
 		84FA975819A5D3580053B2FD /* TestUniquePingProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FA975719A5D3580053B2FD /* TestUniquePingProfile.m */; };
 		84FA975B19A5F1DE0053B2FD /* TestUniqueTimeoutProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FA975A19A5F1DE0053B2FD /* TestUniqueTimeoutProfile.m */; };
 		84FA975D19A608ED0053B2FD /* RESTfulFailConnectProfileTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FA975C19A608ED0053B2FD /* RESTfulFailConnectProfileTest.m */; };
@@ -106,6 +103,7 @@
 		AB043C901BDF6A3500B35D96 /* RESTfulNormalLightProfileTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AB043C8F1BDF6A3500B35D96 /* RESTfulNormalLightProfileTest.m */; };
 		AB043C931BDF6B4000B35D96 /* TestLightProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = AB043C921BDF6B3F00B35D96 /* TestLightProfile.m */; };
 		AB81AC881BDF7C250069F6EB /* RESTfulFailLightProfileTest.m in Sources */ = {isa = PBXBuildFile; fileRef = AB81AC871BDF7C250069F6EB /* RESTfulFailLightProfileTest.m */; };
+		ABF1B0981E3CC7B90033B059 /* dConnectDeviceTestTests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 309CD533198B2CCF002A5684 /* dConnectDeviceTestTests-Info.plist */; };
 		ABF842BC19E3E07300B8AC46 /* DConnectSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABF842BB19E3E07300B8AC46 /* DConnectSDK.framework */; };
 		D63350C11D6C3E2600CB9E5A /* TestService.m in Sources */ = {isa = PBXBuildFile; fileRef = D63350C01D6C3E2600CB9E5A /* TestService.m */; };
 		D646EDC71D6D1AEE0092CBA7 /* TestDriveControllerProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = D646EDC61D6D1AEE0092CBA7 /* TestDriveControllerProfile.m */; };
@@ -257,10 +255,7 @@
 		84EBE7D619B5E2340089AD35 /* AccessToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AccessToken.m; path = dConnectManager/AccessToken.m; sourceTree = "<group>"; };
 		84EBE7E919B6EE480089AD35 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		84EBE8ED19B88BFB0089AD35 /* RESTfulFailAuthorizationProfileTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = RESTfulFailAuthorizationProfileTest.m; path = dConnectManager/RESTful/RESTfulFailAuthorizationProfileTest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		84FA974C19A4CF430053B2FD /* RESTfulStressTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RESTfulStressTest.m; path = dConnectManager/RESTful/RESTfulStressTest.m; sourceTree = "<group>"; };
 		84FA974E19A5942E0053B2FD /* RESTfulFailBatteryProfileTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = RESTfulFailBatteryProfileTest.m; path = dConnectManager/RESTful/RESTfulFailBatteryProfileTest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		84FA975119A59CBD0053B2FD /* RESTfulFailCommonTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; name = RESTfulFailCommonTest.m; path = dConnectManager/RESTful/RESTfulFailCommonTest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
-		84FA975419A5C8850053B2FD /* RESTfulNormalCommonTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RESTfulNormalCommonTest.m; path = dConnectManager/RESTful/RESTfulNormalCommonTest.m; sourceTree = "<group>"; };
 		84FA975619A5D3580053B2FD /* TestUniquePingProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestUniquePingProfile.h; sourceTree = "<group>"; };
 		84FA975719A5D3580053B2FD /* TestUniquePingProfile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestUniquePingProfile.m; sourceTree = "<group>"; };
 		84FA975919A5F1DE0053B2FD /* TestUniqueTimeoutProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestUniqueTimeoutProfile.h; sourceTree = "<group>"; };
@@ -489,7 +484,6 @@
 				845458B71999A4EB0017F06D /* RESTfulTestCase.h */,
 				845458B81999A4EB0017F06D /* RESTfulTestCase.m */,
 				AB043C8F1BDF6A3500B35D96 /* RESTfulNormalLightProfileTest.m */,
-				84FA975419A5C8850053B2FD /* RESTfulNormalCommonTest.m */,
 				6B19E86D1A6FBBB900161F21 /* RESTfulNormalAvailabilityProfileTest.m */,
 				84EBE7D319B5CB1B0089AD35 /* RESTfulNormalAuthorizationProfileTest.m */,
 				845458BF1999D2160017F06D /* RESTfulNormalBatteryProfileTest.m */,
@@ -507,7 +501,6 @@
 				8428953B19A2002500D9ECFF /* RESTfulNormalSettingsProfileTest.m */,
 				8428953C19A2002500D9ECFF /* RESTfulNormalSystemProfileTest.m */,
 				8428953D19A2002500D9ECFF /* RESTfulNormalVibrationProfileTest.m */,
-				84FA975119A59CBD0053B2FD /* RESTfulFailCommonTest.m */,
 				84EBE8ED19B88BFB0089AD35 /* RESTfulFailAuthorizationProfileTest.m */,
 				84FA974E19A5942E0053B2FD /* RESTfulFailBatteryProfileTest.m */,
 				84FA975C19A608ED0053B2FD /* RESTfulFailConnectProfileTest.m */,
@@ -525,7 +518,6 @@
 				AB81AC871BDF7C250069F6EB /* RESTfulFailLightProfileTest.m */,
 				6BD1F6F11A9EC6B2005956F5 /* RESTfulFailServiceInformationProfileTest.m */,
 				84FA976019A615400053B2FD /* RESTfulFailVibrationProfileTest.m */,
-				84FA974C19A4CF430053B2FD /* RESTfulStressTest.m */,
 			);
 			name = RESTful;
 			sourceTree = "<group>";
@@ -724,6 +716,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ABF1B0981E3CC7B90033B059 /* dConnectDeviceTestTests-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -798,14 +791,12 @@
 				848EB54D19A33394001F307F /* RESTfulNormalServiceDiscoveryProfileTest.m in Sources */,
 				8428954719A2002500D9ECFF /* RESTfulNormalVibrationProfileTest.m in Sources */,
 				840DC9CD19A70FF500CA2EA0 /* RESTfulFailNotificationProfileTest.m in Sources */,
-				84FA974D19A4CF430053B2FD /* RESTfulStressTest.m in Sources */,
 				840DC9CB19A6FD7200CA2EA0 /* RESTfulFailPhoneProfileTest.m in Sources */,
 				8428954419A2002500D9ECFF /* RESTfulNormalProximityProfileTest.m in Sources */,
 				8490A34F19A488350031FD1E /* RESTfulFailSystemProfileTest.m in Sources */,
 				8428953F19A2002500D9ECFF /* RESTfulNormalFileProfileTest.m in Sources */,
 				8428954219A2002500D9ECFF /* RESTfulNormalNotificationProfileTest.m in Sources */,
 				8428954519A2002500D9ECFF /* RESTfulNormalSettingsProfileTest.m in Sources */,
-				84FA975219A59CBD0053B2FD /* RESTfulFailCommonTest.m in Sources */,
 				8490A35019A488350031FD1E /* RESTfulFailNetworkServiceDiscoveryProfileTest.m in Sources */,
 				6BD1F6F21A9EC6B2005956F5 /* RESTfulFailServiceInformationProfileTest.m in Sources */,
 				845458AE1998E9D50017F06D /* SRWebSocket.m in Sources */,
@@ -827,7 +818,6 @@
 				845458D019A1C34D0017F06D /* Hash.m in Sources */,
 				AB043C901BDF6A3500B35D96 /* RESTfulNormalLightProfileTest.m in Sources */,
 				84FA975F19A610BA0053B2FD /* RESTfulFailDeviceOrientationProfileTest.m in Sources */,
-				84FA975519A5C8850053B2FD /* RESTfulNormalCommonTest.m in Sources */,
 				845458C919A1C2A90017F06D /* RESTfulNormalFileDescriptorProfileTest.m in Sources */,
 				84EBE7D719B5E2340089AD35 /* AccessToken.m in Sources */,
 				845458C319A199F50017F06D /* RESTfulNormalConnectProfileTest.m in Sources */,
@@ -922,7 +912,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_MODULE_NAME = dConnectDeviceTest_framework;
 				PRODUCT_NAME = dConnectDeviceTest_framework;
@@ -958,7 +948,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				PRODUCT_MODULE_NAME = dConnectDeviceTest_framework;
 				PRODUCT_NAME = dConnectDeviceTest_framework;
 				SDKROOT = iphoneos;
@@ -1100,7 +1090,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = "dConnectDeviceTest_resources/dConnectDeviceTest_resources-Info.plist";
+				INFOPLIST_FILE = "dConnectDeviceTestTests/dConnectDeviceTestTests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1125,7 +1115,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = "dConnectDeviceTest_resources/dConnectDeviceTest_resources-Info.plist";
+				INFOPLIST_FILE = "dConnectDeviceTestTests/dConnectDeviceTestTests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest.xcodeproj/project.pbxproj
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		ABF1B0981E3CC7B90033B059 /* dConnectDeviceTestTests-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 309CD533198B2CCF002A5684 /* dConnectDeviceTestTests-Info.plist */; };
 		ABF1B09B1E3CD8B30033B059 /* TestAllGetControlProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = ABF1B09A1E3CD8B30033B059 /* TestAllGetControlProfile.m */; };
 		ABF1B09D1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m in Sources */ = {isa = PBXBuildFile; fileRef = ABF1B09C1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m */; };
+		ABF1B09F1E3DA7A00033B059 /* RESTfulFailAllGetControlTest.m in Sources */ = {isa = PBXBuildFile; fileRef = ABF1B09E1E3DA7A00033B059 /* RESTfulFailAllGetControlTest.m */; };
 		ABF842BC19E3E07300B8AC46 /* DConnectSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ABF842BB19E3E07300B8AC46 /* DConnectSDK.framework */; };
 		D63350C11D6C3E2600CB9E5A /* TestService.m in Sources */ = {isa = PBXBuildFile; fileRef = D63350C01D6C3E2600CB9E5A /* TestService.m */; };
 		D646EDC71D6D1AEE0092CBA7 /* TestDriveControllerProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = D646EDC61D6D1AEE0092CBA7 /* TestDriveControllerProfile.m */; };
@@ -275,6 +276,7 @@
 		ABF1B0991E3CD8B30033B059 /* TestAllGetControlProfile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestAllGetControlProfile.h; sourceTree = "<group>"; };
 		ABF1B09A1E3CD8B30033B059 /* TestAllGetControlProfile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestAllGetControlProfile.m; sourceTree = "<group>"; };
 		ABF1B09C1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RESTfulNormalAllGetControlTest.m; path = dConnectManager/RESTful/RESTfulNormalAllGetControlTest.m; sourceTree = "<group>"; };
+		ABF1B09E1E3DA7A00033B059 /* RESTfulFailAllGetControlTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RESTfulFailAllGetControlTest.m; path = dConnectManager/RESTful/RESTfulFailAllGetControlTest.m; sourceTree = "<group>"; };
 		ABF842BB19E3E07300B8AC46 /* DConnectSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DConnectSDK.framework; path = ../../dConnectSDK/dConnectSDKForIOS/bin/DConnectSDK.framework; sourceTree = "<group>"; };
 		D63350BF1D6C3E2600CB9E5A /* TestService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestService.h; sourceTree = "<group>"; };
 		D63350C01D6C3E2600CB9E5A /* TestService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestService.m; sourceTree = "<group>"; };
@@ -526,6 +528,7 @@
 				6BD1F6F11A9EC6B2005956F5 /* RESTfulFailServiceInformationProfileTest.m */,
 				84FA976019A615400053B2FD /* RESTfulFailVibrationProfileTest.m */,
 				ABF1B09C1E3D97630033B059 /* RESTfulNormalAllGetControlTest.m */,
+				ABF1B09E1E3DA7A00033B059 /* RESTfulFailAllGetControlTest.m */,
 			);
 			name = RESTful;
 			sourceTree = "<group>";
@@ -798,6 +801,7 @@
 				8428954019A2002500D9ECFF /* RESTfulNormalMediaPlayerProfileTest.m in Sources */,
 				84EBE8EE19B88BFB0089AD35 /* RESTfulFailAuthorizationProfileTest.m in Sources */,
 				848EB54D19A33394001F307F /* RESTfulNormalServiceDiscoveryProfileTest.m in Sources */,
+				ABF1B09F1E3DA7A00033B059 /* RESTfulFailAllGetControlTest.m in Sources */,
 				8428954719A2002500D9ECFF /* RESTfulNormalVibrationProfileTest.m in Sources */,
 				840DC9CD19A70FF500CA2EA0 /* RESTfulFailNotificationProfileTest.m in Sources */,
 				840DC9CB19A6FD7200CA2EA0 /* RESTfulFailPhoneProfileTest.m in Sources */,

--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest/Classes/Profile/TestAllGetControlProfile.h
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest/Classes/Profile/TestAllGetControlProfile.h
@@ -1,0 +1,14 @@
+//
+//  TestAllGetControlProfile.h
+//  dConnectDeviceTest
+//
+//  Copyright (c) 2014 NTT DOCOMO, INC.
+//  Released under the MIT license
+//  http://opensource.org/licenses/mit-license.php
+//
+
+#import <DConnectSDK/DConnectSDK.h>
+
+@interface TestAllGetControlProfile : DConnectProfile
+
+@end

--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest/Classes/Profile/TestAllGetControlProfile.m
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest/Classes/Profile/TestAllGetControlProfile.m
@@ -1,0 +1,104 @@
+//
+//  TestAllGetControlProfile.m
+//  dConnectDeviceTest
+//
+//  Copyright (c) 2014 NTT DOCOMO, INC.
+//  Released under the MIT license
+//  http://opensource.org/licenses/mit-license.php
+//
+#import "TestAllGetControlProfile.h"
+
+
+NSString *const AllGetControlProfileProfileName = @"allGetControl";
+NSString *const AllGetControlProfileInterfaceTest = @"test";
+NSString *const AllGetControlProfileAttributePing = @"ping";
+NSString *const AllGetControlProfileParamKey = @"key";
+
+NSString *const AllGetControlProfileValueProfile = @"PROFILE_OK";
+NSString *const AllGetControlProfileValueInterface = @"INTERFACE_OK";
+NSString *const AllGetControlProfileValueAttribute = @"ATTRIBUTE_OK";
+
+@implementation TestAllGetControlProfile
+
+- (id) init {
+    self = [super init];
+    
+    if (self) {
+        
+        NSString *allGetControlApiPathProfile = [self apiPath:nil attributeName:nil];
+        NSString *allGetControlApiPathProfileAttribute = [self apiPath:nil attributeName:AllGetControlProfileAttributePing];
+        NSString *allGetControlApiPathProfileInterfaceAttribute = [self apiPath:AllGetControlProfileInterfaceTest
+                                                                  attributeName:AllGetControlProfileAttributePing];
+        /* Profile */
+        [self addGetPath:allGetControlApiPathProfile api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueProfile
+                                                                     response:response];
+        }];
+        [self addPostPath:allGetControlApiPathProfile api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueProfile
+                                                                     response:response];
+        }];
+        [self addPutPath:allGetControlApiPathProfile api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueProfile
+                                                                     response:response];
+        }];
+        [self addDeletePath:allGetControlApiPathProfile api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueProfile
+                                                                     response:response];
+        }];
+        /* Profile Attribute */
+        [self addGetPath:allGetControlApiPathProfileAttribute api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueAttribute
+                                                                     response:response];
+        }];
+        [self addPostPath:allGetControlApiPathProfileAttribute api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueAttribute
+                                                                     response:response];
+        }];
+        [self addPutPath:allGetControlApiPathProfileAttribute api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueAttribute
+                                                                     response:response];
+        }];
+        [self addDeletePath:allGetControlApiPathProfileAttribute api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueAttribute
+                                                                     response:response];
+        }];
+        /** Profile Interface Attribute */
+        [self addGetPath:allGetControlApiPathProfileInterfaceAttribute api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueInterface
+                                                                     response:response];
+        }];
+        [self addPostPath:allGetControlApiPathProfileInterfaceAttribute api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueInterface
+                                                                     response:response];
+        }];
+        [self addPutPath:allGetControlApiPathProfileInterfaceAttribute api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueInterface
+                                                                     response:response];
+        }];
+        [self addDeletePath:allGetControlApiPathProfileInterfaceAttribute api: ^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+            return [TestAllGetControlProfile setResponseParametersWithMessage:AllGetControlProfileValueInterface
+                                                                     response:response];
+        }];
+    }
+    
+    return self;
+}
+
+#pragma mark - DConnect Profile Methods
+
+- (NSString *) profileName {
+    return AllGetControlProfileProfileName;
+}
+
+#pragma mark - Private Methods
+
++ (BOOL) setResponseParametersWithMessage:(NSString*)message
+                              response:(DConnectResponseMessage*)response
+{
+    response.result = DConnectMessageResultTypeOk;
+    [response setString:message forKey:AllGetControlProfileParamKey];
+    return YES;
+}
+
+@end

--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest/Classes/TestService.m
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTest/Classes/TestService.m
@@ -27,6 +27,7 @@
 #import "TestRemoteControllerProfile.h"
 #import "TestDriveControllerProfile.h"
 #import "TestOmnidirectionalImageProfile.h"
+#import "TestAllGetControlProfile.h"
 
 NSString *const TestNetworkServiceIdSpecialCharacters = @"!#$'()-~¥@[;+:*],._/=?&%^|`\"{}<>";
 NSString *const TestNetworkDeviceName = @"Test Success Device";
@@ -69,6 +70,7 @@ static NSString *const TestNetworkDeviceConfig = @"test config";
         [self addProfile:[TestUniquePingProfile new]];
         [self addProfile:[TestUniqueTimeoutProfile new]];
         [self addProfile:[TestUniqueEventProfile new]];
+        [self addProfile:[TestAllGetControlProfile new]];
     }
     return self;
     

--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTestTests/dConnectDeviceTestTests-Info.plist
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTestTests/dConnectDeviceTestTests-Info.plist
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright (c) 2014 NTT DOCOMO, INC. Released under the MIT license.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>dConnectDeviceTest</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
@@ -20,5 +20,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright (c) 2014 NTT DOCOMO, INC. Released under the MIT license.</string>
 </dict>
 </plist>

--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTestTests/dConnectManager/RESTful/RESTfulFailAllGetControlTest.m
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTestTests/dConnectManager/RESTful/RESTfulFailAllGetControlTest.m
@@ -1,0 +1,1320 @@
+//
+//  RESTfulFailAllGetControlTest.m
+//  dConnectDeviceTest
+//
+//  Copyright (c) 2014 NTT DOCOMO, INC.
+//  Released under the MIT license
+//  http://opensource.org/licenses/mit-license.php
+//
+
+#import "RESTfulTestCase.h"
+
+@interface RESTfulFailAllGetControlTest : RESTfulTestCase
+
+@end
+
+@implementation RESTfulFailAllGetControlTest
+
+#pragma mark - POST invalid test
+/*!
+ * @brief HTTPメソッドがPOSTで、/profileのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /GET/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostGetRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、/profile/attributeのとき、methodにGETが指定されている時に、エラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /GET/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostGetRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、/profile/interface/attributeのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /GET/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostGetRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、/profileのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /POST/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostPostRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、 /profile/attributeのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /POST/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostPostRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、/profile/interface/attributeのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /POST/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostPostRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+
+/*!
+ * @brief HTTPメソッドがPOSTで、/profileのとき、methodにPUTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /PUT/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostPutRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、/profile/attributeのとき、methodにPUTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /PUT/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostPutRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、 /profile/interface/attributeのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /PUT/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostPutRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @briefHTTPメソッドがPOSTで、 /profileのとき、methodにDELETEが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /DELETE/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostDeleteRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、/profile/attributeのとき、methodにDELETEが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /DELETE/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostDeleteRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPOSTで、/profile/interface/attributeのとき、methodにDELETEが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: POST
+ * Path: /DELETE/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPostDeleteRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"POST"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+#pragma mark - PUT invalid test
+/*!
+ * @brief HTTPメソッドがPUTで、/profileのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /GET/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutGetRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、/profile/attributeのとき、methodにGETが指定されている時に、エラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /GET/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutGetRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、/profile/interface/attributeのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /GET/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutGetRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、/profileのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /POST/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutPostRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、 /profile/attributeのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /POST/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutPostRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、/profile/interface/attributeのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /POST/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutPostRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+
+/*!
+ * @brief HTTPメソッドがPUTで、/profileのとき、methodにPUTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /PUT/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutPutRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、/profile/attributeのとき、methodにPUTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /PUT/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutPutRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、 /profile/interface/attributeのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /PUT/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutPutRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、 /profileのとき、methodにDELEteが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /DELETE/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutDeleteRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、/profile/attributeのとき、methodにDELETEが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /DELETE/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutDeleteRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがPUTで、/profile/interface/attributeのとき、methodにDELETEが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: PUT
+ * Path: /DELETE/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodPutDeleteRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"PUT"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+
+#pragma mark - DELETE invalid test
+/*!
+ * @brief HTTPメソッドがDELETEで、/profileのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /GET/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeleteGetRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、/profile/attributeのとき、methodにGETが指定されている時に、エラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /GET/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeleteGetRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、/profile/interface/attributeのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /GET/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeleteGetRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、/profileのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /POST/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeletePostRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、 /profile/attributeのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /POST/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeletePostRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、/profile/interface/attributeのとき、methodにPOSTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /POST/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeletePostRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+
+/*!
+ * @brief HTTPメソッドがDELETEで、/profileのとき、methodにPUTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /PUT/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeletePutRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、/profile/attributeのとき、methodにPUTが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /PUT/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeletePutRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、 /profile/interface/attributeのとき、methodにGETが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /PUT/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeletePutRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、 /profileのとき、methodにDELEteが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /DELETE/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeleteDeleteRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、/profile/attributeのとき、methodにDELETEが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /DELETE/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeleteDeleteRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+/*!
+ * @brief HTTPメソッドがDELETEで、/profile/interface/attributeのとき、methodにDELETEが指定されている時にエラー処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: DELETE
+ * Path: /DELETE/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid urlエラーが返って来ること。
+ * </pre>
+ */
+- (void) testHttpMethodDeleteDeleteRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"DELETE"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":19}", request);
+}
+
+
+#pragma mark - Method指定時にProfileにHttpメソッドが指定されている
+/*!
+ * @brief methodが指定されていない時、profile名にGETが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /GET?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodGetByNormal
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodが指定されていない時、profile名にPOSTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /POST?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPostByNormal
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodが指定されていない時、profile名にPUTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /PUT?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPutByNormal
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodが指定されていない時、profile名にDELETEが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /DELETE?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodDeleteByNormal
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+
+#pragma mark - Method指定時にProfileにHttpメソッドが指定されている
+/*!
+ * @brief methodがGETで指定されている時、profile名にGETが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /GET/GET?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodGetGetByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/GET?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @briefmethodがGETで指定されている時、profile名にGETが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /GET/POST?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodGetPostByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/POST?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にGETが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /GET/PUT?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodGetPutByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/PUT?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にGETが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /GET/DELETE?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodGetDeleteByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/DELETE?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にPOSTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /POST/GET?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPostGetByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/GET?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief  methodがGETで指定されている時、profile名にPOSTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /POST/POST?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPostPostByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/POST?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にPOSTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /POST/PUT?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPostPutByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/PUT?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にPOSTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /POST/DELETE?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPostDeleteByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/DELETE?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にPUTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /PUT/GET?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPutGetByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/GET?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にPUTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /PUT/POST?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPutPostByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/POST?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にPUTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /PUT/PUT?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPutPutByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/PUT?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にPUTが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /PUT/DELETE?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodPutDeleteByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/DELETE?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にDELETEが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /DELETE/GET?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodDeleteGetByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/GET?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にDELETEが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /DELETE/POST?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodDeletePostByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/POST?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にDELETEが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /DELETE/PUT?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodDeletePutByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/PUT?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+/*!
+ * @brief methodがGETで指定されている時、profile名にDELETEが指定されている場合はエラー処理する.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /DELETE/DELETE?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに1が返ってくること。
+ * ・Invalid profileエラーが返って来ること。
+ * </pre>
+ */
+- (void) testProfileHttpMethodDeleteByAllGetControl
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/DELETE?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":1,\"errorCode\":20}", request);
+}
+
+
+@end

--- a/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTestTests/dConnectManager/RESTful/RESTfulNormalAllGetControlTest.m
+++ b/dConnectDevicePlugin/dConnectDeviceTest/dConnectDeviceTestTests/dConnectManager/RESTful/RESTfulNormalAllGetControlTest.m
@@ -1,0 +1,306 @@
+//
+//  RESTfuleNormalAllGetControlTest.m
+//  dConnectDeviceTest
+//
+//  Copyright (c) 2014 NTT DOCOMO, INC.
+//  Released under the MIT license
+//  http://opensource.org/licenses/mit-license.php
+//
+
+#import "RESTfulTestCase.h"
+
+
+@interface RESTfulNormalAllGetControlTest : RESTfulTestCase
+
+@end
+/*!
+ @class RESTfulNormalAllGetControlTest
+ @brief RESTful 全てGETで操作する機能の正常系テスト。
+ */
+@implementation RESTfulNormalAllGetControlTest
+
+
+/*!
+ * @brief /profileのとき、methodにGETが指定されている時でも、正常にリクエストが処理されること。
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /GET/allGetControl?serviceId=xxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ */
+- (void) testGetRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"PROFILE_OK\"}", request);
+}
+
+/*!
+ * @brief /profile/attributeのとき、methodにGETが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /GET/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ *
+ */
+- (void) testGetRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"ATTRIBUTE_OK\"}", request);
+}
+
+/*!
+ * @brief /profile/interface/attributeのとき、methodにGETが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /GET/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ */
+- (void) testGetRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/GET/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"INTERFACE_OK\"}", request);
+}
+
+
+/*!
+ * @brief /profileのとき、methodにPOSTが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /POST/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ */
+- (void) testPostRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"PROFILE_OK\"}", request);
+}
+
+/*!
+ * @brief /profile/attributeのとき、methodにPOSTが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /POST/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ *
+ */
+- (void) testPostRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"ATTRIBUTE_OK\"}", request);
+}
+
+/*!
+ * @brief /profile/interface/attributeのとき、methodにPOSTが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /POSt/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ */
+- (void) testPostRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/POST/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"INTERFACE_OK\"}", request);
+}
+
+
+/*!
+ * @brief /profileのとき、methodにPUTが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /PUT/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ */
+- (void) testPutRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"PROFILE_OK\"}", request);
+}
+
+/*!
+ * @brief /profile/attributeのとき、methodにPUTが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /PUT/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ *
+ */
+- (void) testPutRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"ATTRIBUTE_OK\"}", request);
+}
+
+/*!
+ * @brief /profile/interface/attributeのとき、methodにGETが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /PUT/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ */
+- (void) testPutRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/PUT/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"INTERFACE_OK\"}", request);
+}
+
+
+/*!
+ * @brief /profileのとき、methodにDELEteが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /DELETE/allGetControl?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ *
+ */
+- (void) testDeleteRequestProfile
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"PROFILE_OK\"}", request);
+}
+
+/*!
+ * @brief /profile/attributeのとき、methodにDELETEが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /DELETE/allGetControl/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ */
+- (void) testDeleteRequestProfileAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"ATTRIBUTE_OK\"}", request);
+}
+
+/*!
+ * @brief /profile/interface/attributeのとき、methodにDELETEが指定されている時でも、正常にリクエストが処理されること.
+ * <pre>
+ * 【HTTP通信】
+ * Method: GET
+ * Path: /DELETE/allGetControl/test/ping?serviceId&accessToken=xxxx
+ * </pre>
+ * <pre>
+ * 【期待する動作】
+ * ・resultに0が返ってくること。
+ * ・デバイスプラグインで指定されているレスポンスがそのまま返されること
+ * </pre>
+ */
+- (void) testDeleteRequestProfileInterfaceAttribute
+{
+    NSURL *uri = [NSURL URLWithString:
+                  [NSString stringWithFormat:@"http://localhost:4035/gotapi/DELETE/allGetControl/test/ping?serviceId=%@", self.serviceId]];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:uri];
+    [request setHTTPMethod:@"GET"];
+    
+    CHECK_RESPONSE(@"{\"result\":0,\"key\":\"INTERFACE_OK\"}", request);
+}
+
+@end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectResponseMessage.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectResponseMessage.m
@@ -186,4 +186,21 @@
     [self setError:DConnectMessageErrorCodeInvalidOrigin message:message];
 }
 
+
+- (void) setErrorToInvalidURL {
+    [self setErrorToInvalidURLWithMessage:@"Request url is invalid."];
+}
+
+- (void) setErrorToInvalidURLWithMessage:(NSString *)message {
+    [self setError:DConnectMessageErrorCodeInvalidURL message:message];
+}
+
+- (void) setErrorToInvalidProfile {
+    [self setErrorToInvalidURLWithMessage:@"Profile name is invalid."];
+}
+
+- (void) setErrorToInvalidProfileWithMessage:(NSString *)message {
+    [self setError:DConnectMessageErrorCodeInvalidProfile message:message];
+}
+
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectResponseMessage.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectResponseMessage.m
@@ -196,7 +196,7 @@
 }
 
 - (void) setErrorToInvalidProfile {
-    [self setErrorToInvalidURLWithMessage:@"Profile name is invalid."];
+    [self setErrorToInvalidProfileWithMessage:@"Profile name is invalid."];
 }
 
 - (void) setErrorToInvalidProfileWithMessage:(NSString *)message {

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/http/DConnectServerManager.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/http/DConnectServerManager.m
@@ -29,7 +29,9 @@
 typedef NS_ENUM(NSInteger, RequestExceptionType) {
     HAVE_NO_API_EXCEPTION,
     HAVE_NO_PROFILE_EXCEPTION,
-    NOT_SUPPORT_ACTION_EXCEPTION
+    NOT_SUPPORT_ACTION_EXCEPTION,
+    INVALID_URL_EXCEPTION,
+    INVALID_PROFILE_EXCEPTION
 };
 
 
@@ -196,6 +198,23 @@ typedef NS_ENUM(NSInteger, RequestExceptionType) {
                     [response setStatusCode:501];
                     [response respondWithString:error.domain encoding:NSUTF8StringEncoding];
                 }   break;
+                case INVALID_URL_EXCEPTION: {
+                    DConnectResponseMessage *responseMessage = [DConnectResponseMessage new];
+                    [responseMessage setResult:DConnectMessageResultTypeError];
+                    [responseMessage setVersion:[DConnectManager sharedManager].versionName];
+                    [responseMessage setProduct:[DConnectManager sharedManager].productName];
+                    [responseMessage setErrorToInvalidURL];
+                    [self convertDConnectResponse:responseMessage DConnectRequest:nil toResponse:response Request:request];
+                }   break;
+                case INVALID_PROFILE_EXCEPTION: {
+                    DConnectResponseMessage *responseMessage = [DConnectResponseMessage new];
+                    [responseMessage setResult:DConnectMessageResultTypeError];
+                    [responseMessage setVersion:[DConnectManager sharedManager].versionName];
+                    [responseMessage setProduct:[DConnectManager sharedManager].productName];
+                    [responseMessage setErrorToInvalidProfile];
+                    [self convertDConnectResponse:responseMessage DConnectRequest:nil toResponse:response Request:request];
+                }   break;
+
                 default: {
                     DConnectResponseMessage *responseMessage = [DConnectResponseMessage new];
                     [responseMessage setResult:DConnectMessageResultTypeError];
@@ -317,7 +336,7 @@ typedef NS_ENUM(NSInteger, RequestExceptionType) {
     } else if ([self existHttpMethod:profile]) {
         if (error) {
             *error = [NSError errorWithDomain:@"Profile name is invalid."
-                                         code:20
+                                         code:INVALID_PROFILE_EXCEPTION
                                      userInfo:nil];
         }
         return nil;
@@ -340,7 +359,7 @@ typedef NS_ENUM(NSInteger, RequestExceptionType) {
     } else if (httpMethod && methodId != DConnectMessageActionTypeGet) {
         if (error) {
             *error = [NSError errorWithDomain:@"Request url is invalid"
-                                         code:19
+                                         code:INVALID_URL_EXCEPTION
                                      userInfo:nil];
         }
         return nil;

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/profile/DConnectProfile.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/profile/DConnectProfile.m
@@ -126,7 +126,7 @@
                 [response setErrorToNotSupportAction];
             }
         } else {
-            [response setErrorToUnknownAttribute];
+            [response setErrorToNotSupportAction];
         }
         return YES;
     }

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectMessage.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectMessage.h
@@ -141,6 +141,8 @@ typedef NS_ENUM(NSUInteger, DConnectMessageErrorCodeType) {
     DConnectMessageErrorCodeIllegalDeviceState,       /*!< デバイスの状態異常エラー */
     DConnectMessageErrorCodeIllegalServerState,       /*!< サーバーの状態異常エラー */
     DConnectMessageErrorCodeInvalidOrigin,            /*!< 不正なオリジンからリクエストを受信した */
+    DConnectMessageErrorCodeInvalidURL,               /*!< 不正なリクエストURLを受信した */
+    DConnectMessageErrorCodeInvalidProfile,            /*!< 不正なProfileを受信した */
 };
 
 @class DConnectResponseMessage;

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectResponseMessage.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectResponseMessage.h
@@ -274,4 +274,27 @@
  */
 - (void) setErrorToInvalidOriginWithMessage:(NSString *)message;
 
+
+/*!
+ @brief レスポンスエラーを不正URLに設定する。
+ */
+- (void) setErrorToInvalidURL;
+
+/*!
+ @brief レスポンスエラーを不正URLに設定し、指定された文字列をエラーメッセージに設定する。
+ 
+ @param[in] message エラーメッセージ
+ */
+- (void) setErrorToInvalidURLWithMessage:(NSString *)message;
+/*!
+ @brief レスポンスエラーを不正Profileエラーに設定する。
+ */
+- (void) setErrorToInvalidProfile;
+
+/*!
+ @brief レスポンスエラーを不正Profileエラーに設定し、指定された文字列をエラーメッセージに設定する。
+ 
+ @param[in] message エラーメッセージ
+ */
+- (void) setErrorToInvalidProfileWithMessage:(NSString *)message;
 @end


### PR DESCRIPTION
# 内容
* DeviceConnectのリクエストURLにHTTPメソッドを指定することによりGETで操作することができる
 * 例）http://localhost:4035/gotapi/put/vibration/vibrate?serviceId=xxxx
* マルチパートとイベントの取得（WebSocketの代用）は非対応