### PR TITLE
Linkingデバイスの再接続処理を修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/DPLinkingDevicePlugin.m
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/DPLinkingDevicePlugin.m
@@ -10,6 +10,7 @@
 #import "DPLinkingDevicePlugin.h"
 #import "DPLinkingServiceDiscoveryProfile.h"
 #import "DPLinkingSystemProfile.h"
+#import "DPLinkingDeviceManager.h"
 
 @implementation DPLinkingDevicePlugin
 
@@ -24,9 +25,25 @@
 
         [self addProfile:[[DPLinkingServiceDiscoveryProfile alloc] initWithServiceProvider: self.serviceProvider]];
         [self addProfile:[DPLinkingSystemProfile systemProfileWithVersion:@"1.0"]];
+
+        __weak typeof(self) weakSelf = self;
+        
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+            UIApplication *application = [UIApplication sharedApplication];
+            [notificationCenter addObserver:weakSelf
+                                   selector:@selector(enterForeground)
+                                       name:UIApplicationWillEnterForegroundNotification
+                                     object:application];
+        });
     }
     return self;
 }
+
+- (void) enterForeground {
+    [[DPLinkingDeviceManager sharedInstance] restart];
+}
+
 #pragma mark - DevicePlugin's icon image
 
 - (NSString*)iconFilePath:(BOOL)isOnline

--- a/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDevice.m
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDevice.m
@@ -34,6 +34,7 @@ static NSString *const kConnectFlag = @"connectFlag";
         self.vibrationOffPatternId = [[coder decodeObjectForKey:kVibrationOffPatternId] intValue];
         self.connectFlag = [[coder decodeObjectForKey:kConnectFlag] boolValue];
         self.temperatureType = DCMTemperatureProfileEnumCelsius;
+        self.online = NO;
 
         DCLogInfo(@"LDPDevice");
         DCLogInfo(@"    name: %@", self.name);

--- a/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDevice.m
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDevice.m
@@ -40,6 +40,7 @@ static NSString *const kConnectFlag = @"connectFlag";
         DCLogInfo(@"    id: %@", self.identifier);
         DCLogInfo(@"    led: %d", self.ledOffPatternId);
         DCLogInfo(@"    vibration: %d", self.vibrationOffPatternId);
+        DCLogInfo(@"    connectFlag: %@", self.connectFlag ? @"YES" : @"NO");
     }
     return self;
 }

--- a/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDeviceManager.h
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDeviceManager.h
@@ -72,6 +72,8 @@
 - (void) stopScan;
 - (BOOL) isStartScan;
 
+- (void) restart;
+
 - (NSArray *) getDPLinkingDevices;
 
 - (DPLinkingDevice *) createDPLinkingDevice:(CBPeripheral *)peripheral;

--- a/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDeviceManager.m
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDeviceManager.m
@@ -102,6 +102,10 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
     return [[BLEConnecter sharedInstance] isScanning];
 }
 
+- (void) restart {
+    [self startScanWithTimeout:20];
+}
+
 - (DPLinkingDevice *) findDPLinkingDeviceByPeripheral:(CBPeripheral *)peripheral {
     __block DPLinkingDevice *result = nil;
     [self.devices enumerateObjectsUsingBlock:^(DPLinkingDevice *obj, NSUInteger idx, BOOL *stop) {
@@ -635,6 +639,7 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
 
 - (void) startScanWithTimeout:(NSTimeInterval)timeout {
     if ([BLEConnecter sharedInstance].canDiscovery) {
+        DCLogInfo(@"DPLinkingDeviceManager::startScanWithTimeout");
         [DPLinkingUtil asyncAfterDelay:timeout block:^{
             DCLogWarn(@"Timeout.");
             _initFlag = NO;
@@ -836,7 +841,7 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
             [self stopScan];
             [self connectDPLinkingDevice:device];
         } else if (_initFlag) {
-            if (device.connectFlag) {
+            if (device.connectFlag && !device.online) {
                 [self connectDPLinkingDevice:device];
             }
         }

--- a/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDeviceManager.m
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/linking/DPLinkingDeviceManager.m
@@ -204,6 +204,7 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
     
     [[BLEConnecter sharedInstance] disconnectByDeviceUUID:device.peripheral.identifier.UUIDString];
     device.connectFlag = NO;
+    device.peripheral = nil;
     [self saveDPLinkingDevice];
 }
 
@@ -800,12 +801,18 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
 }
 
 - (void) failToConnect:(CBPeripheral *)peripheral {
-    DCLogInfo(@"AAAAA failToConnect: %@", peripheral);
+    BLEDeviceSetting *setting = [[BLEConnecter sharedInstance] getDeviceByPeripheral:peripheral];
+    
+    DCLogInfo(@"@@ failToConnect: [デバイス：%@ との接続に失敗しました。]", setting.name);
+    DCLogInfo(@"    setting.notifyDeviceInitial: %@", setting.notifyDeviceInitial ? @"YES" : @"NO");
+    DCLogInfo(@"    setting.initialDeviceSettingFinished: %@", setting.initialDeviceSettingFinished ? @"YES" : @"NO");
+    DCLogInfo(@"    setting.saved: %@", setting.saved ? @"YES" : @"NO");
+    DCLogInfo(@"    setting.connectionStatus: %@", setting.connectionStatus);
     
     if ([self isEqualDeviceUuid:peripheral]) {
         DPLinkingDevice *device = [self findDPLinkingDeviceByPeripheral:peripheral];
         if (device) {
-            device.setting = [[BLEConnecter sharedInstance] getDeviceByPeripheral:peripheral];
+            device.setting = setting;
             device.online = NO;
             
             [self notifyFailToConnectDevice:device];
@@ -821,17 +828,15 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
     if (device) {
         device.peripheral = peripheral;
 
-        if (_initFlag) {
-            if (device.connectFlag) {
-                [self connectDPLinkingDevice:device];
+        if ([self isEqualDeviceUuid:peripheral]) {
+            if (_scanTimerCancelBlock) {
+                _scanTimerCancelBlock();
+                _scanTimerCancelBlock = nil;
             }
-        } else {
-            if ([self isEqualDeviceUuid:peripheral]) {
-                if (_scanTimerCancelBlock) {
-                    _scanTimerCancelBlock();
-                    _scanTimerCancelBlock = nil;
-                }
-                [self stopScan];
+            [self stopScan];
+            [self connectDPLinkingDevice:device];
+        } else if (_initFlag) {
+            if (device.connectFlag) {
                 [self connectDPLinkingDevice:device];
             }
         }
@@ -850,7 +855,12 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
 }
 
 - (void)didConnectDevice:(BLEDeviceSetting *)setting {
-    DCLogInfo(@"@@ didConnectDevice [デバイス：%@ と接続されました。]: %@", setting.name, setting.initialDeviceSettingFinished ? @"true" : @"false");
+    DCLogInfo(@"@@ didConnectDevice: [デバイス：%@ と接続されました。]", setting.name);
+    DCLogInfo(@"    setting.notifyDeviceInitial: %@", setting.notifyDeviceInitial ? @"YES" : @"NO");
+    DCLogInfo(@"    setting.initialDeviceSettingFinished: %@", setting.initialDeviceSettingFinished ? @"YES" : @"NO");
+    DCLogInfo(@"    setting.saved: %@", setting.saved ? @"YES" : @"NO");
+    DCLogInfo(@"    setting.connectionStatus: %@", setting.connectionStatus);
+
     setting.isInDistanceThreshold = YES;
 }
 
@@ -859,7 +869,7 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
     
     BLEDeviceSetting *setting = [[BLEConnecter sharedInstance] getDeviceByPeripheral:peripheral];
 
-    DCLogInfo(@"デバイスを発見しました。");
+    DCLogInfo(@"デバイスの初期化が完了しました");
     DCLogInfo(@"    name : %@", setting.peripheral.name);
     DCLogInfo(@"    device id : %d", setting.deviceId);
     DCLogInfo(@"    device uid : %d", setting.deviceUid);
@@ -887,7 +897,7 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
 }
 
 - (void)didDisconnectPeripheral:(CBPeripheral *)peripheral {
-    DCLogInfo(@"@@ didDisconnectPeripheral");
+    DCLogInfo(@"@@ didDisconnectPeripheral: %@", peripheral);
 
     DPLinkingDevice *device = [self findDPLinkingDeviceByPeripheral:peripheral];
     if (device) {
@@ -896,7 +906,7 @@ static DPLinkingDeviceManager* _sharedInstance = nil;
 }
 
 - (void) didDisconnectDevice:(BLEDeviceSetting *)setting {
-    DCLogInfo(@"@@ didDisconnectDevice");
+    DCLogInfo(@"@@ didDisconnectDevice: %@", setting.peripheral);
 
     DPLinkingDevice *device = [self findDPLinkingDeviceByPeripheral:setting.peripheral];
     if (device) {

--- a/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/ui/DPLinkingSearchViewController.m
+++ b/dConnectDevicePlugin/dConnectDeviceLinking/dConnectDeviceLinking/Classes/ui/DPLinkingSearchViewController.m
@@ -70,7 +70,7 @@
 }
 
 - (void) paringPeripheral:(CBPeripheral *)peripheral {
-    DCLogInfo(@"paringPeripheral");
+    DCLogInfo(@"paringPeripheral: %@", peripheral);
     
     _disconnectCount = 0;
     

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectManager.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectManager.m
@@ -231,9 +231,6 @@ NSString *const DConnectAttributeNameRequestAccessToken = @"requestAccessToken";
 
     _requestQueue = dispatch_queue_create("org.deviceconnect.manager.queue.request", DISPATCH_QUEUE_SERIAL);
     
-    // デバイスプラグインの検索
-    [self.mDeviceManager searchDevicePlugin];
-    
     _webServer = [DConnectServerManager new];
     _webServer.settings = self.settings;
     
@@ -249,7 +246,6 @@ NSString *const DConnectAttributeNameRequestAccessToken = @"requestAccessToken";
         return;
     }
     self.mStartFlag = NO;
-
     [_webServer stopServer];
 }
 
@@ -451,6 +447,9 @@ NSString *const DConnectAttributeNameRequestAccessToken = @"requestAccessToken";
         self.mEventSessionTable = [DConnectEventSessionTable new];
         self.mEventBroker = [[DConnectEventBroker alloc] initWithContext:self table:self.mEventSessionTable localOAuth:self.mLocalOAuth pluginManager:self.mDeviceManager delegate:self.delegate];
         
+        // デバイスプラグインの検索
+        [self.mDeviceManager searchDevicePlugin];
+
         // プロファイルの追加
         [self addProfile:[DConnectManagerServiceDiscoveryProfile new]];
         [self addProfile:[DConnectManagerSystemProfile new]];


### PR DESCRIPTION
Linkingデバイスを再接続した時に接続できない問題を修正
以下の点を確認してください。
・LinkingデバイスをBluetooth圏外まで持ち運び戻ってきた時に再接続されるか。
・Linkingデバイス一覧画面で、On/Offを繰り返しても問題がないか。
・Linkingデバイス一覧画面で削除した後に、Linkingデバイス検索画面から再接続ができるか。
・iOS端末のBluetooth設定をOn/Offを繰り返しても再接続されるか。