### PR TITLE
各UIのナビゲーションバーの色調整。

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHAddBookmarkController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHAddBookmarkController.m
@@ -64,6 +64,17 @@
     self.navigationItem.rightBarButtonItem = done;
     
 }
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
+}
 
 
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHBookmarkTopController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHBookmarkTopController.m
@@ -57,11 +57,16 @@
     self.folderBtn.tintColor = [UIColor colorWithWhite:0 alpha:0];
     isEditing = NO;
 }
-
-
-- (void)viewWillAppear:(BOOL)animated
-{
-    [super viewWillAppear:animated];
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
     //ツールバーのボタン非表示
     self.navigationController.toolbarHidden = NO;
     [self setEdiMode:isEditing];

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHBookmarkViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHBookmarkViewController.m
@@ -46,14 +46,20 @@
 }
 
 
-- (void)viewWillAppear:(BOOL)animated
-{
-    [super viewWillAppear:animated];
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
     self.title = self.parent.title;
     [self setEdiMode:isEditing];
     self.navigationController.toolbarHidden = NO;
 }
-
 
 - (void)didReceiveMemoryWarning
 {

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHDeviceListViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHDeviceListViewController.m
@@ -173,9 +173,16 @@
     self.title = @"デバイス一覧";
 }
 
-- (void)viewDidAppear:(BOOL)animated
-{
-    [super viewDidAppear:animated];
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
     [viewModel setup];
 }
 

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHDevicePluginDetailViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHDevicePluginDetailViewController.m
@@ -40,6 +40,17 @@
     self.tableView.rowHeight = UITableViewAutomaticDimension;
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
+}
 - (void)openDevicePluginSetting
 {
     DConnectSystemProfile *systemProfile = [viewModel findSystemProfile];

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHDevicePluginTableViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHDevicePluginTableViewController.m
@@ -50,7 +50,17 @@
     self.tableView.estimatedRowHeight = 80;
     self.tableView.rowHeight = UITableViewAutomaticDimension;
 }
-
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
+}
 //--------------------------------------------------------------//
 #pragma mark - tableViewDelegate
 //--------------------------------------------------------------//

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHFolderCreateController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHFolderCreateController.m
@@ -47,6 +47,17 @@
     [self.tableView registerNib:[UINib nibWithNibName:@"GHFolderTitleCell" bundle:nil] forCellReuseIdentifier:CELL_TITLE];
 }
 
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
+}
 
 - (void)setDirectory
 {

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHFoldersListController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHFoldersListController.m
@@ -47,14 +47,20 @@
     self.title = @"フォルダを選択";
     [self setup];
 }
-
-- (void)viewWillAppear:(BOOL)animated
-{
-    [super viewWillAppear:animated];
-    
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
     self.navigationController.toolbarHidden = YES;
     self.treeView.frame = self.view.bounds;
 }
+
 
 
 - (void)didReceiveMemoryWarning

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingController.m
@@ -65,7 +65,17 @@
     [super viewDidLoad];
     self.title = @"設定";
 }
-
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
+}
 - (IBAction)close
 {
     [viewModel updateSwitchState];

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/WebViewController.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/WebViewController.m
@@ -127,6 +127,17 @@ static const char kAssocKey_Window;
                                                                   action:@selector(close:)];
     self.navigationItem.leftBarButtonItem = closeButton;
 }
+- (void)viewWillAppear:(BOOL)animated {
+    // デバイスプラグインの設定画面で、全体のナビゲーションバーの色を変えられた時のために、Browserデフォルトの色に戻す。
+    self.navigationController.navigationBar.barTintColor =[UIColor whiteColor];
+    self.navigationController.navigationBar.tintColor =  [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor blackColor]};
+    [UINavigationBar appearance].barTintColor = [UIColor whiteColor];
+    [UINavigationBar appearance].tintColor = [UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000];
+    [UITabBar appearance].translucent = NO;
+    [UITabBar appearance].barTintColor = [UIColor whiteColor];
+    [[UITabBar appearance] setTintColor:[UIColor colorWithRed:0.000 green:0.549 blue:0.890 alpha:1.000]];
+}
 
 - (void)close:(UIBarButtonItem*)item
 {

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/viewcontroller/DConnectServiceListViewController.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/viewcontroller/DConnectServiceListViewController.m
@@ -49,7 +49,13 @@
 }
 
 - (void)viewWillAppear:(BOOL)animated {
-    
+    // 他のデバイスプラグインで全てのナビゲーションバーの色が変えられた時のために色を設定する
+    self.navigationController.navigationBar.barTintColor = [UIColor colorWithRed:0.00
+                                                                           green:0.63
+                                                                            blue:0.91
+                                                                           alpha:1.0];
+    self.navigationController.navigationBar.tintColor = [UIColor whiteColor];
+    self.navigationController.navigationBar.titleTextAttributes = @{NSForegroundColorAttributeName: [UIColor whiteColor]};
     // 再表示(バックグラウンド中に通知されたDConnectServiceListener(サービス追加／削除／状態変化)がTableViewに適用されていないので再表示する)
     [self.tableView reloadData];
     


### PR DESCRIPTION
# 修正内容
* デバイスプラグイン側で全体のナビゲーションバーの色が変えられた時のために、Browser側の色に戻す。
  * 現状、Linkingデバイスプラグインの設定画面を開い後に戻ってくると発生する。