### PR TITLE
DConnectSDKのリファレンスの記載漏れを追加

### DIFF
--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectApiEntity.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectApiEntity.h
@@ -14,10 +14,30 @@
 
 typedef BOOL (^DConnectApiFunction)(DConnectRequestMessage*, DConnectResponseMessage*);
 
+/*!
+ @class DConnectApiEntity
+ @brief Device Connect APIを実装するオブジェクト。
+ */
 @interface DConnectApiEntity : NSObject<NSCopying>
+
+/*!
+ @brief APIのメソッド名。
+ */
 @property (nonatomic, strong) NSString *method;
+
+/*!
+ @brief APIのパス名。
+ */
 @property (nonatomic, strong) NSString *path;
+
+/*!
+ @brief APIを実装するブロック。
+ */
 @property (nonatomic, strong) DConnectApiFunction api;
+
+/*!
+ @brief APIの仕様を定義するオブジェクトのインスタンス。
+ */
 @property (nonatomic, strong) DConnectApiSpec *apiSpec;
 
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectApiSpec.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectApiSpec.h
@@ -12,27 +12,66 @@
 #import <DConnectSDK/DConnectRequestMessage.h>
 #import <DConnectSDK/DConnectSpecConstants.h>
 
+/*!
+ @class DConnectApiSpec
+ @brief Device Connect API仕様。
+ */
 @interface DConnectApiSpec : NSObject<NSCopying>
 
+/*!
+ @brief API種別。
+ */
 @property(nonatomic) DConnectSpecType type;
 
+/*!
+ @brief APIメソッド。
+ */
 @property(nonatomic) DConnectSpecMethod method;
 
+/*!
+ @brief API名。
+ */
 @property(nonatomic, strong) NSString *apiName;
 
+/*!
+ @brief プロファイル名。
+ */
 @property(nonatomic, strong) NSString *profileName;
 
+/*!
+ @brief インターフェース名。
+ */
 @property(nonatomic, strong) NSString *interfaceName;
 
+/*!
+ @brief アトリビュート名。
+ */
 @property(nonatomic, strong) NSString *attributeName;
 
-// DConnectParamSpecの配列
+
+/*!
+ @brief リクエストパラメータ仕様のリスト。
+ 
+ DConnectParamSpecの配列で表現される。
+ */
 @property(nonatomic, strong) NSArray *requestParamSpecList;
 
+/*!
+ @brief APIのパスを取得する。
+ @return APIのパスを示す文字列。
+ */
 - (NSString *) path;
 
+/*!
+ @brief APIのパスを設定する。
+ @param[in] path APIのパスを示す文字列。
+ */
 - (void) setPath: (NSString *) path;
 
+/*!
+ @brief アプリケーションからのリクエストを検証する。
+ @return リクエストが仕様通りであると判断された場合はYES、そうでない場合はNO
+ */
 - (BOOL) validate: (DConnectRequestMessage *) request;
 
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectAvailabilityProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectAvailabilityProfile.h
@@ -21,6 +21,13 @@ extern NSString *const DConnectAvailabilityProfileName;
 
 extern NSString *const DConnectAvailabilityProfileParamName;
 
+/*!
+ @class DConnectAvailabilityProfile
+ @brief Availabilityプロファイル。
+ 
+ Managerと通信可能であることを確認するためのプロファイル。
+ プラグイン側では実装する必要はない。
+ */
 @interface DConnectAvailabilityProfile : DConnectProfile
 
 - (id) init;

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectBatteryProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectBatteryProfile.h
@@ -80,6 +80,10 @@ extern NSString *const DConnectBatteryProfileParamBattery;
  
  Battery Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectBatteryProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectCanvasProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectCanvasProfile.h
@@ -75,6 +75,10 @@ extern NSString *const DConnectCanvasProfileModeFills;
  
  Canvas Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectCanvasProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectConnectionProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectConnectionProfile.h
@@ -85,6 +85,10 @@ extern NSString *const DConnectConnectionProfileParamConnectStatus;
  
  Connect Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectConnectionProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectDeviceOrientationProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectDeviceOrientationProfile.h
@@ -85,6 +85,10 @@ extern NSString *const DConnectDeviceOrientationProfileParamAccelerationIncludin
  
  Device Orientation Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectDeviceOrientationProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectFileDescriptorProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectFileDescriptorProfile.h
@@ -98,8 +98,12 @@ extern NSString *const DConnectFileDescriptorProfileParamPath;
  @class DConnectFileDescriptorProfile
  @brief File Descriptorプロファイル。
  
- File Descriptor Profileの各APIへのリクエストを受信する。
+ File Descriptor Profileの各APIへのリクエストを受信する｡
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectFileDescriptorProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectFileProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectFileProfile.h
@@ -113,6 +113,10 @@ typedef NS_ENUM(NSUInteger, DConnectFileProfileFileType) {
  
  File Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectFileProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectGeolocationProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectGeolocationProfile.h
@@ -106,6 +106,10 @@ extern NSString *const DConnectGeolocationProfileParamTimeStampString;
  
  Geolocation Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectGeolocationProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectKeyEventProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectKeyEventProfile.h
@@ -86,6 +86,10 @@ extern NSString *const DConnectKeyEventProfileKeyStateUp;
  
  Receive request to the Key Event Profile API.
  The received request is reported to the delegate for each API.
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectKeyEventProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectLightProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectLightProfile.h
@@ -83,6 +83,10 @@ extern NSString *const DConnectLightProfileParamGroupName;
  
  Light Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectLightProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectMediaPlayerProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectMediaPlayerProfile.h
@@ -259,6 +259,10 @@ extern NSString *const DConnectMediaPlayerProfileOrderDESC;
  
  Media Player Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectMediaPlayerProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectMediaStreamRecordingProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectMediaStreamRecordingProfile.h
@@ -714,6 +714,10 @@ extern NSString *const DConnectMediaStreamRecordingProfileRecordingStateWarning;
  
  Battery Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectMediaStreamRecordingProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectNotificationProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectNotificationProfile.h
@@ -119,6 +119,10 @@ typedef NS_ENUM(NSInteger, DConnectNotificationProfileNotificationType) {
  
  Notification Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectNotificationProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectPhoneProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectPhoneProfile.h
@@ -82,6 +82,10 @@ typedef NS_ENUM(NSInteger, DConnectPhoneProfileCallState) {
  
  Phone Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectPhoneProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectPluginSpec.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectPluginSpec.h
@@ -10,6 +10,12 @@
 #import <Foundation/Foundation.h>
 #import "DConnectProfileSpec.h"
 
+/*!
+ @class DConnectPluginSpec
+ @brief プラグインのサポートする仕様を保持するクラス。
+ 
+ プラグインのサポートするプロファイルのリストを持つ。
+ */
 @interface DConnectPluginSpec : NSObject
 
 /*!

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectProfileProvider.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectProfileProvider.h
@@ -10,6 +10,10 @@
 #import <Foundation/Foundation.h>
 #import <DConnectSDK/DConnectProfile.h>
 
+/*!
+ @class DConnectProfileProvider
+ @brief Device Connect プロファイルプロバイダー。
+ */
 @interface DConnectProfileProvider : NSObject
 
 /*!

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectProfileSpec.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectProfileSpec.h
@@ -12,14 +12,32 @@
 #import "DConnectSpecConstants.h"
 #import "DConnectProfileSpec.h"
 
+/*!
+ @class DConnectProfileSpec
+ @brief プロファイルについての仕様を保持するクラス。
+ 
+ 当該プロファイル上で定義されるAPIの仕様のリストを持つ。
+ */
 @interface DConnectProfileSpec : NSObject
 
+/*!
+ @brief API仕様定義ファイルの元データ。
+ */
 @property (nonatomic, strong) NSDictionary * bundle;
 
+/*!
+ @brief API名。
+ */
 @property (nonatomic, strong) NSString * api;
 
+/*!
+ @brief プロファイル名.
+ */
 @property (nonatomic, strong) NSString * profile;
 
+/*!
+ @brief 当該プロファイルのもつDConnectApiSpec一覧。
+ */
 @property (nonatomic, strong) NSMutableDictionary * allApiSpecs;    // Map<String, Map<Method, DConnectApiSpec>>
 
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectProximityProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectProximityProfile.h
@@ -76,6 +76,10 @@ extern NSString *const DConnectProximityProfileRangeUnknown;;
  
  Proximity Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectProximityProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectService.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectService.h
@@ -17,35 +17,73 @@ extern NSString * const DConnectServiceAnonymousOrigin;
 extern NSString * const DConnectServiceInnerType;
 extern NSString * const DConnectServiceInnerTypeHttp;
 
-
 @class DConnectService;
 
+/*!
+ @brief DConnectServiceの状態変更通知を受信するリスナー。
+ */
 @protocol OnStatusChangeListener <NSObject>
 
+/*!
+ @brief DConnectServiceの状態が変更された時に呼び出される。
+ @param[in] 状態の変更されたDConnectServiceのインスタンス。
+ */
 - (void) didStatusChange: (DConnectService *)service;
 
 @end
 
+/*!
+ @class DConnectService
+ @brief Device Connect APIサービス。
+ */
 @interface DConnectService : DConnectProfileProvider<DConnectServiceInformationProfileDataSource>
 
 /*!
- @brief サービスID.
+ @brief サービスID。
  */
 @property(nonatomic, strong) NSString *serviceId;
 
+/*!
+ @brief サービス名。
+ */
 @property(nonatomic, strong) NSString *name;
 
+/*!
+ @brief ネットワーク種別。
+ */
 @property(nonatomic, strong) NSString *networkType;
 
+/*!
+ @brief オンライン状態。
+ 
+ ホストデバイスと接続されているかどうかを示すフラグ。
+ */
 @property(readwrite, getter=online, setter=setOnline:) BOOL online;
 
+/*!
+ @brief コンフィグ。
+ 
+ サービスごとに任意に設定可能な文字列。
+ */
 @property(nonatomic, strong) NSString *config;
 
+/*!
+ @brief 当該サービスの状態変更を通知するリスナー。
+ */
 @property(nonatomic, weak) id<OnStatusChangeListener> statusListener;
 
-
+/*!
+ @brief DConnectServiceのインスタンスを生成する。
+ @param[in] serviceId サービスID。
+ @param[in] plugin DConnectDevicePluginのインスタンス。
+ @return DConnectServiceのインスタンス。
+ */
 - (instancetype) initWithServiceId: (NSString *)serviceId plugin: (id) plugin;
 
+/*!
+ @brief リクエスト受信時に実行される。
+ @return 同期的にリクエストを処理する場合はYES、それ以外の場合(非同期処理を行う場合)はNO。後者の場合は、非同期処理完了後に明示的にレスポンス送信処理を実行すること。
+ */
 - (BOOL) didReceiveRequest: (DConnectRequestMessage *) request response: (DConnectResponseMessage *)response;
 
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectServiceListViewController.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectServiceListViewController.h
@@ -11,14 +11,30 @@
 #import <DConnectSDK/DConnectSystemProfile.h>
 #import <DConnectSDK/DConnectServiceListener.h>
 
+/*!
+ @class DConnectServiceListViewController
+ @brief DeviceConnectサービス一覧を表示するUI。
+ */
 @interface DConnectServiceListViewController : UITableViewController<DConnectServiceListener>
 
+/*!
+ @brief Systemプロファイルのデリゲート。
+ */
 @property (nonatomic, weak) id<DConnectSystemProfileDelegate> delegate;
 
+/*!
+ @brief サービス追加ボタン。
+ */
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *addButton;
 
+/*!
+ @brief サービス追加または削除の完了ボタン。
+ */
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *finishButton;
 
+/*!
+ @brief サービス削除ボタン。
+ */
 @property (weak, nonatomic) IBOutlet UIBarButtonItem *removeButton;
 
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectServiceListener.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectServiceListener.h
@@ -9,13 +9,28 @@
 
 @class DConnectService;
 
+/*!
+ @brief サービス一覧の状態変更通知を受信するリスナー。
+ */
 @protocol DConnectServiceListener <NSObject>
 @optional
 
+/*!
+ @brief サービスが追加された時に実行される。
+ @param[in] 追加されたサービス。
+ */
 - (void) didServiceAdded: (DConnectService *) service;
 
+/*!
+ @brief サービスが削除された時に実行される。
+ @param[in] 削除されたサービス。
+ */
 - (void) didServiceRemoved: (DConnectService *) service;
 
+/*!
+ @brief サービスの状態が変更された時に実行される。
+ @param[in] 状態の変更されたサービス。
+ */
 - (void) didStatusChange: (DConnectService *) service;
 
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectServiceManager.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectServiceManager.h
@@ -12,6 +12,10 @@
 #import <DConnectSDK/DConnectServiceProvider.h>
 #import <DConnectSDK/DConnectPluginSpec.h>
 
+/*!
+ @class DConnectServiceManager
+ @brief 当該プラグインのDeviceConnectサービスを管理する。
+ */
 @interface DConnectServiceManager : DConnectServiceProvider<OnStatusChangeListener>
 
 
@@ -29,6 +33,10 @@
  */
 + (DConnectServiceManager *)sharedForKey: (NSString *)key;
 
+/*!
+ @brief プラグインを対応づける。
+ @param[in] plugin DConnectDevicePluginのインスタンス。
+ */
 - (void) setPlugin: (id) plugin;
 
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectServiceProvider.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectServiceProvider.h
@@ -13,37 +13,71 @@
 
 @class DConnectService;
 
+/*!
+ @class DConnectServiceProvider
+ @brief プラグインのサービス管理機能のインターフェース。
+ */
 @interface DConnectServiceProvider : NSObject
 
+/*!
+ @brief サービスの公開元であるプラグインを取得する。
+ @return DConnectDevicePluginのインスタンス。
+ */
 - (id) plugin;
 
+/*!
+ @brief 指定されたサービスを保持しているかどうかを返す。
+ @param[in] serviceId サービスID
+ @return 保持している場合はYES、そうでない場合はNO
+ */
 - (BOOL) hasService: (NSString *) serviceId;
 
+/*!
+ @brief 指定されたサービスのインスタンスを返す。
+ @param[in] serviceId サービスID
+ @return DConnectServiceのインスタンス。存在しなかった場合は、nilを返す。
+ */
 - (DConnectService *) service: (NSString *) serviceId;
 
 /*!
- @brief サービス配列を返す.
+ @brief サービス配列を返す。
  @retval DConnectServiceの配列
  */
 - (NSArray *) services;
 
+/*!
+ @brief サービスを追加する。
+ @param[in] service DConnectServiceのインスタンス
+ */
 - (void) addService: (DConnectService *) service;
 
+/*!
+ @brief サービスを追加する。
+ @param[in] service DConnectServiceのインスタンス
+ @param[in] selfBundle NSBundleのインスタンス
+ */
 - (void) addService: (DConnectService *) service bundle:(NSBundle *) selfBundle;
 
+/*!
+ @brief サービスを削除する。
+ @param[in] service DConnectServiceのインスタンス
+ */
 - (void) removeService: (DConnectService *) service;
 
+/*!
+ @brief 全てのサービスを削除する。
+ */
 - (void) removeAllServices;
 
 /*!
- * @brief サービスの追加または削除イベントを受信するためのリスナーを追加する.
- * @param[in] listener リスナー
+ @brief サービスの追加または削除イベントを受信するためのリスナーを追加する。
+ @param[in] listener リスナー
  */
 - (void) addServiceListener: (id<DConnectServiceListener>) listener;
 
 /*!
- * サービスの追加または削除イベントを受信するためのリスナーを削除する.
- * @param[in] listener リスナー
+ @brief サービスの追加または削除イベントを受信するためのリスナーを削除する。
+ @param[in] listener リスナー
  */
 - (void) removeServiceListener: (id<DConnectServiceListener>) listener;
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectSettingProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectSettingProfile.h
@@ -100,6 +100,10 @@ typedef NS_ENUM(NSInteger, DConnectSettingProfileVolumeKind) {
  
  Setting Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectSettingProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectSpecConstants.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectSpecConstants.h
@@ -91,20 +91,110 @@ extern NSString * const DConnectSpecBoolTrue;
 #define DConnectSpecBoolValues()    {NO, YES}
 
 
-
+/*!
+ @class DConnectSpecConstants
+ @brief Device Connect APIを定義する上で使用される定数、ユーティリティ関数を提供する。
+ */
 @interface DConnectSpecConstants : NSObject
 
+/*!
+ @brief 文字列をDConnectSpecTypeに変換する。
+ @param[in] strType 文字列
+ @param[out] outType DConnectSpecType
+ @param[out] error 変換時のエラー
+ @return 変換に成功した場合はYES、失敗した場合はNO
+ */
 + (BOOL) parseType: (NSString *)strType outType: (DConnectSpecType *) outType error: (NSError **) error;
+
+/*!
+ @brief DConnectSpecTypeを文字列に変換する。
+ @param[in] type DConnectSpecType
+ @param[out] error 変換時のエラー
+ @return 文字列
+ */
 + (NSString *) toTypeString: (DConnectSpecType)type error:(NSError **) error;
+
+/*!
+ @brief 文字列をDConnectSpecMethodに変換する。
+ @param[in] strMethod 文字列
+ @param[out] outMethod DConnectSpecMethod
+ @param[out] error 変換時のエラー
+ @return 変換に成功した場合はYES、失敗した場合はNO
+ */
 + (BOOL) parseMethod: (NSString *)strMethod outMethod: (DConnectSpecMethod *) outMethod error: (NSError **) error;
+
+/*!
+ @brief DConnectMessageActionTypeをDConnectSpecMethodに変換する。
+ @param[in] method DConnectMessageActionType
+ @param[out] outMethod DConnectSpecMethod
+ @param[out] error 変換時のエラー
+ @return 変換に成功した場合はYES、失敗した場合はNO
+ */
 + (BOOL) toMethodFromAction: (DConnectMessageActionType) method outMethod: (DConnectSpecMethod *) outMethod error: (NSError **) error;
+
+/*!
+ @brief DConnectSpecMethodを文字列に変換する。
+ @param[in] method DConnectSpecMethod
+ @param[out] error 変換時のエラー
+ @return 文字列
+ */
 + (NSString *) toMethodString: (DConnectSpecMethod)method error: (NSError **) error;
+
+/*!
+ @brief 文字列をDConnectSpecDataTypeに変換する。
+ @param[in] strDataType 文字列
+ @param[out] outDataType DConnectSpecDataType
+ @param[out] error 変換時のエラー
+ @return 変換に成功した場合はYES、失敗した場合はNO
+ */
 + (BOOL) parseDataType: (NSString *)strDataType outDataType: (DConnectSpecDataType *) outDataType error: (NSError **) error;
+
+/*!
+ @brief DConnectSpecDataTypeを文字列に変換する。
+ @param[in] dataType DConnectSpecDataType
+ @param[out] error 変換時のエラー
+ @return 文字列
+ */
 + (NSString *) toDataTypeString: (DConnectSpecDataType)dataType error:(NSError **) error;
+
+/*!
+ @brief 文字列をDConnectSpecDataFormatに変換する。
+ @param[in] strDataFormat 文字列
+ @param[out] outDataFormat DConnectSpecDataFormat
+ @param[out] error 変換時のエラー
+ @return 変換に成功した場合はYES、失敗した場合はNO
+ */
 + (BOOL) parseDataFormat: (NSString *)strDataFormat outDataFormat: (DConnectSpecDataFormat *) outDataFormat error:(NSError **) error;
+
+/*!
+ @brief DConnectSpecDataFormatを文字列に変換する。
+ @param[in] dataFormat DConnectSpecDataFormat
+ @param[out] error 変換時のエラー
+ @return 文字列
+ */
 + (NSString *) toDataFormatString: (DConnectSpecDataFormat)dataFormat error:(NSError **)error;
+
+/*!
+ @brief オブジェクトのインスタンスをBOOLに変換する。
+ @param[in] 変換元のインスタンス
+ @param[out] 変換先のBOOLへのポインタ
+ @param[out] 変換時のエラー
+ @return 変換に成功した場合はYES、失敗した場合はNO
+ */
 + (BOOL) parseBool: (id)idBool outBoolValue: (BOOL *)outBoolValue error:(NSError **) error;
-+ (BOOL)isDigit:(NSString *)text;
-+ (BOOL)isNumber:(NSString *)text;
+
+/*!
+ @brief 指定された文字列が整数値を表現しているかどうかを返す。
+ @param[in] text 文字列
+ @return 整数値表現である場合はYES、そうでない場合はNO
+ */
++ (BOOL) isDigit:(NSString *)text;
+
+/*!
+ @brief 指定された文字列が実数値を表現しているかどうかを返す。
+ @param[in] text 文字列
+ @return 実数値表現である場合はYES、そうでない場合はNO
+ */
++ (BOOL) isNumber:(NSString *)text;
 
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectSystemProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectSystemProfile.h
@@ -80,30 +80,48 @@ extern NSString *const DConnectSystemProfileParamVersion;
 
 @class DConnectSystemProfile;
 
+/*!
+ @protocol DConnectSystemProfileDelegate
+ @brief Systemプロファイルのデリゲート。
+ */
 @protocol DConnectSystemProfileDelegate <NSObject>
 
+/*!
+ @brief サービス管理機能のインスタンスを取得する。
+ @return DConnectServiceProviderのインスタンス。
+ */
 - (DConnectServiceProvider *) serviceProvider;
 
+/*!
+ @brief 設定画面のUI管理クラスのインスタンスを取得する。
+ @return UIViewControllerのインスタンス。
+ */
 - (UIViewController *) settingViewController;
 
 @optional
 
 /*!
- @brief サービスが選択された時に呼び出します.
- 
+ @brief サービスが選択された時に呼び出される。
  @param[in] service 選択されたサービス
  */
 - (void) didSelectService: (DConnectService *) service;
 
 /*!
- @brief サービスが削除された時に呼び出します.
- 
+ @brief サービスが削除された時に呼び出される。
  @param[in] service 削除されたサービス
  */
 - (void) didRemovedService:(DConnectService *) service;
 
+/*!
+ @brief サービス一覧画面が表示された時に呼び出される。
+ */
 - (void) serviceListViewControllerDidWillAppear;
 
+/*!
+ @brief 指定されたサービス一覧をフィルタリングし、画面中に表示するサービスの配列を返す。
+ @param[in] サービスの配列
+ @return 実際に画面上に表示するサービスの配列
+ */
 - (NSArray *) displayServiceFilter: (NSArray *) services;
 
 @end

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectTouchProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectTouchProfile.h
@@ -86,6 +86,10 @@ extern NSString *const DConnectTouchProfileParamY;
  
  Receive request to the Touch Profile API.
  The received request is reported to the delegate for each API.
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectTouchProfile : DConnectProfile
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectVibrationProfile.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectVibrationProfile.h
@@ -44,6 +44,10 @@ extern const long long DConnectVibrationProfileDefaultMaxVibrationTime;
  
  Vibration Profileの各APIへのリクエストを受信する。
  受信したリクエストは各API毎にデリゲートに通知される。
+ 
+ @deprecated
+ 本クラスで定義していた定数はSwagger形式の定義ファイルで管理することになったので、このクラスは使用しないこととする。
+ プロファイルを実装する際は本クラスではなく、@link DConnectProfile @endlink クラスを継承すること。
  */
 @interface DConnectVibrationProfile : DConnectProfile
 


### PR DESCRIPTION
## 修正内容

DConnectSDKで提供しているクラスとプロトコルについて、Doxygen形式の記載が漏れていた箇所があったため、追加しました。