### PR TITLE
iPhoneの近接センサ挙動修正

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostProximityProfile.m
+++ b/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostProximityProfile.m
@@ -41,7 +41,8 @@ typedef void (^DPHostProximityBlock)(DConnectMessage *);
             // プロファイルが表示されない様にする。
             return nil;
         }
-        
+        [UIDevice currentDevice].proximityMonitoringEnabled = NO;
+
         // YESを設定してYES；近接センサーがサポートされている。
         __weak DPHostProximityProfile *weakSelf = self;
         self.proximityBlock = nil;

--- a/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostProximityProfile.m
+++ b/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostProximityProfile.m
@@ -15,7 +15,6 @@
 typedef void (^DPHostProximityBlock)(DConnectMessage *);
 
 @interface DPHostProximityProfile ()
-
 /// @brief イベントマネージャ
 @property DConnectEventManager *eventMgr;
 
@@ -51,117 +50,138 @@ typedef void (^DPHostProximityBlock)(DConnectMessage *);
         // イベントマネージャを取得
         self.eventMgr = [DConnectEventManager sharedManagerForClass:[DPHostDevicePlugin class]];
 
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [UIDevice currentDevice].proximityMonitoringEnabled = YES;
-            
-            [[NSNotificationCenter defaultCenter] addObserver:weakSelf
-                                                     selector:@selector(sendOnUserProximityEvent:)
-                                                         name:UIDeviceProximityStateDidChangeNotification
-                                                       object:nil];
 
-            // API登録(didReceiveGetOnUserProximityRequest相当)
-            NSString *getOnUserProximityRequestApiPath = [self apiPath: nil
-                                                         attributeName: DConnectProximityProfileAttrOnUserProximity];
-            [self addGetPath: getOnUserProximityRequestApiPath
-                          api:^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
-                              
-                              DConnectMessage *proximity = [DConnectMessage message];
+        // API登録(didReceiveGetOnUserProximityRequest相当)
+        NSString *getOnUserProximityRequestApiPath = [self apiPath: nil
+                                                     attributeName: DConnectProximityProfileAttrOnUserProximity];
+        [self addGetPath: getOnUserProximityRequestApiPath
+                      api:^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+                          dispatch_async(dispatch_get_main_queue(), ^{
+                              [UIDevice currentDevice].proximityMonitoringEnabled = YES;
+                              [[NSNotificationCenter defaultCenter] addObserver:weakSelf
+                                                                       selector:@selector(sendOnUserProximityEvent:)
+                                                                           name:UIDeviceProximityStateDidChangeNotification
+                                                                         object:nil];
+                          });
+                          dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+                          DConnectMessage *proximity = [DConnectMessage message];
+
+                          [response setResult:DConnectMessageResultTypeOk];
+                          [DConnectProximityProfile setNear:NO target:proximity];
+                          [DConnectProximityProfile setProximity:proximity target:response];
+
+                          weakSelf.onceProximityBlock = ^(DConnectMessage *message) {
                               [response setResult:DConnectMessageResultTypeOk];
-                              
-                              [DConnectProximityProfile setNear:weakSelf.proximityState target:proximity];
-                              [DConnectProximityProfile setProximity:proximity target:response];
-                              
-                              return YES;
-                          }];
-
-            // API登録(didReceivePutOnUserProximityRequest相当)
-            NSString *putOnUserProximityRequestApiPath = [self apiPath: nil
-                                                         attributeName: DConnectProximityProfileAttrOnUserProximity];
-            [self addPutPath: putOnUserProximityRequestApiPath
-                         api:^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
-                             
-                             NSString *serviceId = [request serviceId];
-                             
-                             NSArray *evts = [[weakSelf eventMgr] eventListForServiceId:serviceId
-                                                                      profile:DConnectProximityProfileName
-                                                                    attribute:DConnectProximityProfileAttrOnUserProximity];
-                             if (evts.count == 0) {
-                                 weakSelf.proximityBlock = ^(DConnectMessage *message) {
-                                     // イベントの取得
-                                     NSArray *evts = [weakSelf.eventMgr eventListForServiceId:DPHostDevicePluginServiceId
-                                                                                      profile:DConnectProximityProfileName
-                                                                                    attribute:DConnectProximityProfileAttrOnUserProximity];
-                                     
-                                     DPHostDevicePlugin *plugin = (DPHostDevicePlugin *)weakSelf.plugin;
-                                     // イベント送信
-                                     for (DConnectEvent *evt in evts) {
-                                         DConnectMessage *eventMsg = [DConnectEventManager createEventMessageWithEvent:evt];
-                                         [DConnectProximityProfile setProximity:message target:eventMsg];
-                                         [plugin sendEvent:eventMsg];
-                                     }
-                                 };
-                                 dispatch_async(dispatch_get_main_queue(), ^{
-                                     [UIDevice currentDevice].proximityMonitoringEnabled = YES;
-                                     
-                                     [[NSNotificationCenter defaultCenter] addObserver:weakSelf
-                                                                              selector:@selector(sendOnUserProximityEvent:)
+                              [DConnectProximityProfile setProximity:message target:response];
+                              dispatch_semaphore_signal(semaphore);
+                          };
+                          dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+                          NSString *serviceId = [request serviceId];
+                          dispatch_async(dispatch_get_main_queue(), ^{
+                              NSArray *evts = [[weakSelf eventMgr] eventListForServiceId:serviceId
+                                                                                 profile:DConnectProximityProfileName
+                                                                               attribute:DConnectProximityProfileAttrOnUserProximity];
+                              if (evts.count == 0) {
+                                  [UIDevice currentDevice].proximityMonitoringEnabled = NO;
+                                  
+                                  [[NSNotificationCenter defaultCenter] removeObserver:weakSelf
                                                                                   name:UIDeviceProximityStateDidChangeNotification
                                                                                 object:nil];
-                                 });
-                             }
-                             
-                             switch ([[weakSelf eventMgr] addEventForRequest:request]) {
-                                 case DConnectEventErrorNone:             // エラー無し.
-                                     [response setResult:DConnectMessageResultTypeOk];
-                                     break;
-                                 case DConnectEventErrorInvalidParameter: // 不正なパラメータ.
-                                     [response setErrorToInvalidRequestParameter];
-                                     break;
-                                 case DConnectEventErrorNotFound:         // マッチするイベント無し.
-                                 case DConnectEventErrorFailed:           // 処理失敗.
-                                     [response setErrorToUnknown];
-                                     break;
-                             }
-                             
-                             return YES;
-                         }];
+                                  weakSelf.onceProximityBlock = nil;
+                              }
+                          });
+                          
+                          return YES;
+                      }];
 
-            // API登録(didReceiveDeleteOnUserProximityRequest相当)
-            NSString *deleteOnUserProximityRequestApiPath = [self apiPath: nil
-                                                            attributeName: DConnectProximityProfileAttrOnUserProximity];
-            [self addDeletePath: deleteOnUserProximityRequestApiPath
-                            api:^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
-                             
-                                NSString *serviceId = [request serviceId];
+        // API登録(didReceivePutOnUserProximityRequest相当)
+        NSString *putOnUserProximityRequestApiPath = [self apiPath: nil
+                                                     attributeName: DConnectProximityProfileAttrOnUserProximity];
+        [self addPutPath: putOnUserProximityRequestApiPath
+                     api:^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+                         
+                         NSString *serviceId = [request serviceId];
+                         
+                         NSArray *evts = [[weakSelf eventMgr] eventListForServiceId:serviceId
+                                                                  profile:DConnectProximityProfileName
+                                                                attribute:DConnectProximityProfileAttrOnUserProximity];
+                         if (evts.count == 0) {
+                             weakSelf.proximityBlock = ^(DConnectMessage *message) {
+                                 // イベントの取得
+                                 NSArray *evts = [weakSelf.eventMgr eventListForServiceId:DPHostDevicePluginServiceId
+                                                                                  profile:DConnectProximityProfileName
+                                                                                attribute:DConnectProximityProfileAttrOnUserProximity];
+                                 
+                                 DPHostDevicePlugin *plugin = (DPHostDevicePlugin *)weakSelf.plugin;
+                                 // イベント送信
+                                 for (DConnectEvent *evt in evts) {
+                                     DConnectMessage *eventMsg = [DConnectEventManager createEventMessageWithEvent:evt];
+                                     [DConnectProximityProfile setProximity:message target:eventMsg];
+                                     [plugin sendEvent:eventMsg];
+                                 }
+                             };
+                             dispatch_async(dispatch_get_main_queue(), ^{
+                                 [UIDevice currentDevice].proximityMonitoringEnabled = YES;
+                                 
+                                 [[NSNotificationCenter defaultCenter] addObserver:weakSelf
+                                                                          selector:@selector(sendOnUserProximityEvent:)
+                                                                              name:UIDeviceProximityStateDidChangeNotification
+                                                                            object:nil];
+                             });
+                         }
+                         
+                         switch ([[weakSelf eventMgr] addEventForRequest:request]) {
+                             case DConnectEventErrorNone:             // エラー無し.
+                                 [response setResult:DConnectMessageResultTypeOk];
+                                 break;
+                             case DConnectEventErrorInvalidParameter: // 不正なパラメータ.
+                                 [response setErrorToInvalidRequestParameter];
+                                 break;
+                             case DConnectEventErrorNotFound:         // マッチするイベント無し.
+                             case DConnectEventErrorFailed:           // 処理失敗.
+                                 [response setErrorToUnknown];
+                                 break;
+                         }
+                         
+                         return YES;
+                     }];
+
+        // API登録(didReceiveDeleteOnUserProximityRequest相当)
+        NSString *deleteOnUserProximityRequestApiPath = [self apiPath: nil
+                                                        attributeName: DConnectProximityProfileAttrOnUserProximity];
+        [self addDeletePath: deleteOnUserProximityRequestApiPath
+                        api:^BOOL(DConnectRequestMessage *request, DConnectResponseMessage *response) {
+                         
+                            NSString *serviceId = [request serviceId];
+                            
+                            switch ([[weakSelf eventMgr] removeEventForRequest:request]) {
+                                case DConnectEventErrorNone:             // エラー無し.
+                                    [response setResult:DConnectMessageResultTypeOk];
+                                    break;
+                                case DConnectEventErrorInvalidParameter: // 不正なパラメータ.
+                                    [response setErrorToInvalidRequestParameter];
+                                    break;
+                                case DConnectEventErrorNotFound:         // マッチするイベント無し.
+                                case DConnectEventErrorFailed:           // 処理失敗.
+                                    [response setErrorToUnknown];
+                                    break;
+                            }
+                            
+                            NSArray *evts = [[weakSelf eventMgr] eventListForServiceId:serviceId
+                                                                     profile:DConnectProximityProfileName
+                                                                   attribute:DConnectProximityProfileAttrOnUserProximity];
+                            if (evts.count == 0) {
+                                [UIDevice currentDevice].proximityMonitoringEnabled = NO;
                                 
-                                switch ([[weakSelf eventMgr] removeEventForRequest:request]) {
-                                    case DConnectEventErrorNone:             // エラー無し.
-                                        [response setResult:DConnectMessageResultTypeOk];
-                                        break;
-                                    case DConnectEventErrorInvalidParameter: // 不正なパラメータ.
-                                        [response setErrorToInvalidRequestParameter];
-                                        break;
-                                    case DConnectEventErrorNotFound:         // マッチするイベント無し.
-                                    case DConnectEventErrorFailed:           // 処理失敗.
-                                        [response setErrorToUnknown];
-                                        break;
-                                }
-                                
-                                NSArray *evts = [[weakSelf eventMgr] eventListForServiceId:serviceId
-                                                                         profile:DConnectProximityProfileName
-                                                                       attribute:DConnectProximityProfileAttrOnUserProximity];
-                                if (evts.count == 0) {
-                                    [UIDevice currentDevice].proximityMonitoringEnabled = NO;
-                                    
-                                    [[NSNotificationCenter defaultCenter] removeObserver:weakSelf
-                                                                                    name:UIDeviceProximityStateDidChangeNotification
-                                                                                  object:nil];
-                                    weakSelf.proximityBlock = nil;
-                                }
-                                
-                                return YES;
-                            }];
-        });
+                                [[NSNotificationCenter defaultCenter] removeObserver:weakSelf
+                                                                                name:UIDeviceProximityStateDidChangeNotification
+                                                                              object:nil];
+                                weakSelf.proximityBlock = nil;
+                            }
+                            
+                            return YES;
+                        }];
+
 
     }
     return self;
@@ -191,7 +211,10 @@ typedef void (^DPHostProximityBlock)(DConnectMessage *);
         DPHostProximityBlock block = self.proximityBlock;
         block(proximity);
     }
-    
+    if (self.onceProximityBlock) {
+        DPHostProximityBlock block = self.onceProximityBlock;
+        block(proximity);
+    }
 }
 
 @end


### PR DESCRIPTION
# 修正内容
* Proximityプロファイルを使用していない場合でも、スマートフォンの画面がON/OFFされてしまう挙動の修正。

# 動作確認
* demoWebSiteなどで、Proximityを一度実行し、GETとイベントが実行できることを確認する(この時は、画面が消えても良い)。
* Proximityを終了後、iPhoneの上部に手をかざして画面が消えないことを確認する。
