### PR TITLE
SonyCameraのサービスがサポートしなくて良いProfileが追加されていたので削除

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceSonyCamera/dConnectDeviceSonyCamera/Classes/SonyCameraService.m
+++ b/dConnectDevicePlugin/dConnectDeviceSonyCamera/dConnectDeviceSonyCamera/Classes/SonyCameraService.m
@@ -25,7 +25,6 @@
         [self setName:deviceName];
         [self setNetworkType:DConnectServiceDiscoveryProfileNetworkTypeWiFi];
         [self setOnline:NO];
-        [self addProfile:[DConnectSystemProfile new]];
         [self addProfile:[SonyCameraMediaStreamRecordingProfile new]];
         [self addProfile:[SonyCameraCameraProfile new]];
     }


### PR DESCRIPTION
# 修正内容
* SonyCameraのサービスがサポートしなくて良いProfileが追加されていたので削除。
* デバイスプラグイン側のクラスで追加されていれば良い。