### PR TITLE
Managerのデバイス確認画面の細かい修正

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/demo/checker.html
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/demo/checker.html
@@ -108,7 +108,7 @@
                 </td>
                 <td width="10%">
                     <div>
-                        <input class="text" type="text" name="t_{#name}" value="{#value}">
+                        <input class="text" type="text" name="t_{#name}" value="{#value}" disabled="disabled">
                     </div>
                 </td>
                 <td width="60%">


### PR DESCRIPTION
## 修正内容
* デバイス確認画面のSliderでリクエストパラメータを指定するUIで、キーボードにより値を入力できないようにした。