### PR TITLE
インスタンス生成ロジックの見直し

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/DPHostDevicePlugin.m
+++ b/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/DPHostDevicePlugin.m
@@ -9,7 +9,6 @@
 
 #import <DConnectSDK/DConnectFileManager.h>
 #import <DConnectSDK/DConnectEventManager.h>
-#import <DConnectSDK/DConnectMemoryCacheController.h>
 #import <DConnectSDK/DConnectServiceManager.h>
 
 #import "DPHostDevicePlugin.h"
@@ -22,11 +21,6 @@
 @implementation DPHostDevicePlugin
 
 + (void) initialize {
-    // イベントマネージャの準備
-    Class clazz = [DPHostDevicePlugin class];
-    DConnectEventManager *eventMgr =
-    [DConnectEventManager sharedManagerForClass:clazz];
-    [eventMgr setController:[DConnectMemoryCacheController new]];
 }
 
 - (id) init {

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectDevicePlugin.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectDevicePlugin.m
@@ -50,10 +50,15 @@
         self.pluginVersionName = @"1.0.0";
         self.pluginId = [md5Proc generateSignature: self.pluginName];
 
+        // DeviceConnectサービス管理クラスの初期化
         DConnectServiceManager *serviceManager = [DConnectServiceManager sharedForClass: [object class]];
         [serviceManager setPlugin: self];
         [self setServiceProvider: serviceManager];
         
+        // イベント管理クラスの初期化
+        id<DConnectEventCacheController> ctrl = [self eventCacheController];
+        [[DConnectEventManager sharedManagerForClass:[self class]] setController:ctrl];
+
         // プロファイル追加
         [self addProfile:[[DConnectAuthorizationProfile alloc] initWithObject:self]];
         [self addProfile:[[DConnectServiceDiscoveryProfile alloc] initWithServiceProvider: self.serviceProvider]];
@@ -226,6 +231,11 @@
         return serviceProfiles;
     }
     return nil;
+}
+
+- (id<DConnectEventCacheController>) eventCacheController
+{
+    return [[DConnectMemoryCacheController alloc] init];
 }
 
 

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectDevicePlugin.h
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/DConnectSDK/DConnectDevicePlugin.h
@@ -16,6 +16,7 @@
 #import <DConnectSDK/DConnectRequestMessage.h>
 #import <DConnectSDK/DConnectResponseMessage.h>
 #import <DConnectSDK/DConnectServiceProvider.h>
+#import <DConnectSDK/DConnectEventCacheController.h>
 
 
 /*! 
@@ -114,6 +115,8 @@
  @brief アプリケーションがフォアグランドへの遷移時に呼び出される。
  */
 - (void)applicationWillEnterForeground;
+
+- (id<DConnectEventCacheController>) eventCacheController;
 
 - (NSArray *) serviceProfilesWithServiceId: (NSString *) serviceId;
 


### PR DESCRIPTION
# 修正内容
- DConnectEventManagerの初期化漏れによる Nil アクセスを回避するため、プラグインSDK側で、プラグイン初期化時にデフォルト値としてMemoryCacheControllerのインスタンスを設定しておくように修正。