### PR TITLE
FIle移動APIでNewPathに拡張子がない存在しないファイルが指定された場合の挙動調整

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostFileProfile.m
+++ b/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostFileProfile.m
@@ -169,7 +169,7 @@ static NSString *const DPHostFileProfileParamNewPath = @"newPath";
                           BOOL isExtension = ([dstNewPath pathExtension] && [dstNewPath pathExtension].length > 0)?YES:NO;
                           if (![sysFileMgr fileExistsAtPath:dstNewPath isDirectory:&isDirectory]
                               && !isExtension && !isDirectory) { //拡張子がない存在しないファイルが指定された場合
-                              [response setErrorToInvalidRequestParameterWithMessage:@"NewPath not exist."];
+                              [response setErrorToInvalidRequestParameterWithMessage:@"NewPath has unsupported filename extension."];
                               return YES;
                           } else if ([sysFileMgr fileExistsAtPath:dstNewPath isDirectory:&isDirectory]
                                      && ![[dstNewPath pathExtension] isEqualToString:@""] && !forceOverwrite) {

--- a/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostFileProfile.m
+++ b/dConnectDevicePlugin/dConnectDeviceHost/dConnectDeviceHost/Classes/profile/DPHostFileProfile.m
@@ -166,11 +166,13 @@ static NSString *const DPHostFileProfileParamNewPath = @"newPath";
                               [response setErrorToInvalidRequestParameterWithMessage:@"Directory can not be specified; use Move Directory API instead."];
                               return YES;
                           }
-                          if (![sysFileMgr fileExistsAtPath:dstNewPath isDirectory:&isDirectory]) {
+                          BOOL isExtension = ([dstNewPath pathExtension] && [dstNewPath pathExtension].length > 0)?YES:NO;
+                          if (![sysFileMgr fileExistsAtPath:dstNewPath isDirectory:&isDirectory]
+                              && !isExtension && !isDirectory) { //拡張子がない存在しないファイルが指定された場合
                               [response setErrorToInvalidRequestParameterWithMessage:@"NewPath not exist."];
                               return YES;
                           } else if ([sysFileMgr fileExistsAtPath:dstNewPath isDirectory:&isDirectory]
-                                   && ![[dstNewPath pathExtension] isEqualToString:@""] && !forceOverwrite) {
+                                     && ![[dstNewPath pathExtension] isEqualToString:@""] && !forceOverwrite) {
                               [response setErrorToInvalidRequestParameterWithMessage:@"NewPath File already exist."];
                               return YES;
                           } else if (isDirectory) {

--- a/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectFileManager.m
+++ b/dConnectSDK/dConnectSDKForIOS/DConnectSDK/Classes/DConnectFileManager.m
@@ -570,8 +570,6 @@ static dispatch_queue_t ext2mimeDictLoadQueue;
                                         withIntermediateDirectories:YES
                                                          attributes:nil
                             error:&error];
-    NSLog(@"fileURLWithPath:%@", [NSURL fileURLWithPath:path]);
-    NSLog(@"URLByAppendingPathComponent:%@", [self.URL URLByAppendingPathComponent:path]);
     if (error) {
         DCLogW(@"Failed to create intermediate directories.");
         return nil;


### PR DESCRIPTION
## 更新内容
* FIle移動APIでNewPathに拡張子がない存在しないファイルが指定された場合の挙動調整
* ログ削除