### PR TITLE
Alljoynでライトを操作するとmalloc_errorが発生する

### DIFF
--- a/dConnectDevicePlugin/dConnectDeviceAllJoyn/dConnectDeviceAllJoyn/Sources/Profiles/DPAllJoynLightProfile.mm
+++ b/dConnectDevicePlugin/dConnectDeviceAllJoyn/dConnectDeviceAllJoyn/Sources/Profiles/DPAllJoynLightProfile.mm
@@ -765,7 +765,7 @@ static NSString *const DPAllJoynLightProfileLightIDSelf = @"self";
          
          // MsgArg lacks copy operator, so std::vector can not be used for
          // storing new states...
-         MsgArg newStates[3];
+         MsgArg newStates[4];
          size_t count = 0;
          MsgArg tmp1;
          MsgArg tmp2 = MsgArg("b", YES);


### PR DESCRIPTION
## 修正内容
* 設定するパラメータ用の配列の数を修正。