### PR TITLE
不具合修正: SSLスイッチでサーバーが停止後、再起動しないことがある。

### DIFF
--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.h
@@ -55,4 +55,6 @@ typedef NS_ENUM (NSInteger, SecurityCellType) {
 - (void)didSelectedRow:(NSIndexPath *)indexPath;
 - (BOOL)switchState:(SecurityCellType)type;
 
+-(void)restartManager;
+
 @end

--- a/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
+++ b/dConnectSDK/dConnectBrowserForIOS9/dConnectBrowserForIOS9/classes/GHSettingViewModel.m
@@ -160,13 +160,25 @@
             break;
         case SecurityCellTypeSSL:
             [DConnectManager sharedManager].settings.useSSL = isOn;
-            [[DConnectManager sharedManager] stop];
-            [[DConnectManager sharedManager] start];
+            [self restartManager];
         default:
             break;
     }
 }
 
+- (void)restartManager
+{
+    DConnectManager *mgr = [DConnectManager sharedManager];
+    [mgr stop];
+    int count = 10;
+    do {
+        usleep(50 * 1000); //50ms
+        if ([mgr start]) {
+            return;
+        }
+        count--;
+    } while (count > 0);
+}
 
 ///スイッチの状態を保存
 - (void)updateSwitchState


### PR DESCRIPTION
# 動作確認方法
以下のタイミングでServiceDiscoveryAPIが動作することを確認。
- BrowserForIOS9起動直後
- SSLをONに変更
- SSLをOFFに変更